### PR TITLE
Fix behavior when CMRX is in other than the default location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+message(STATUS "CMRX root dir: ${CMAKE_CURRENT_SOURCE_DIR}")
+set_property(GLOBAL PROPERTY CMRX_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
 include_directories(include)
 include_directories(.)
 include_directories(${CMAKE_BINARY_DIR})

--- a/cmake/CMRX.cmake
+++ b/cmake/CMRX.cmake
@@ -18,9 +18,10 @@ endif()
 function(add_application NAME)
 	add_library(${NAME} STATIC EXCLUDE_FROM_ALL ${ARGN})
 	set_property(TARGET ${NAME} PROPERTY CMRX_IS_APPLICATION 1)
+    get_property(CMRX_ROOT_DIR GLOBAL PROPERTY CMRX_ROOT_DIR)
 	target_compile_definitions(${NAME} PRIVATE -D APPLICATION_NAME=${NAME})
     add_custom_command(TARGET ${NAME} POST_BUILD
-        COMMAND ${CMAKE_SOURCE_DIR}/cmrx/ld/checkapp.sh 
+        COMMAND ${CMRX_ROOT_DIR}/ld/checkapp.sh 
         ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:${NAME}>
         ${NAME}_instance
         COMMENT "Checking application soundness"

--- a/cmake/arch/arm/cmsis/CMRX.cmake
+++ b/cmake/arch/arm/cmsis/CMRX.cmake
@@ -18,12 +18,14 @@ function(add_firmware FW_NAME)
     __cmrx_get_linker_script_for_device(${DEVICE} DEVICE_LINKER_SCRIPT)
     __cmrx_get_linker_script_for_binary(${DEVICE} ${FW_NAME} BINARY_LINKER_SCRIPT)
 
+    get_property(CMRX_ROOT_DIR GLOBAL PROPERTY CMRX_ROOT_DIR)
+
 	if (TESTING)
 		set(EXCL EXCLUDE_FROM_ALL)
 	endif()
 	add_executable(${FW_NAME} ${EXCL} ${ARGN})
     add_custom_command(TARGET ${FW_NAME} POST_BUILD
-        COMMAND python ${CMAKE_SOURCE_DIR}/cmrx/ld/genlink-cmsis.py --realign
+        COMMAND python ${CMRX_ROOT_DIR}/ld/genlink-cmsis.py --realign
             ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:${FW_NAME}>.map 
             ${FW_NAME}
             ${CMAKE_CURRENT_BINARY_DIR}
@@ -36,7 +38,7 @@ function(add_firmware FW_NAME)
     # callouts to different included sub-linker scripts.
     # file(COPY_FILE ${CMAKE_BINARY_DIR}/gen.${DEVICE}.ld ${CMAKE_BINARY_DIR}/gen.${FW_NAME}.${DEVICE}.ld)
     execute_process(
-        COMMAND python ${CMAKE_SOURCE_DIR}/cmrx/ld/genlink-cmsis.py --create 
+        COMMAND python ${CMRX_ROOT_DIR}/ld/genlink-cmsis.py --create 
         ${DEVICE_LINKER_SCRIPT}
         ${BINARY_LINKER_SCRIPT}
         ${FW_NAME}
@@ -52,6 +54,7 @@ function(target_add_applications TGT_NAME)
 
     get_target_property(IS_FIRMWARE ${TGT_NAME} CMRX_IS_FIRMWARE)
     if ("${IS_FIRMWARE}" EQUAL "1")
+        get_property(CMRX_ROOT_DIR GLOBAL PROPERTY CMRX_ROOT_DIR)
         #        message(STATUS "${TGT_NAME} is a firmware, iterating over libraries")
         __cmrx_get_linker_script_for_binary(${DEVICE} ${TGT_NAME} BINARY_LINKER_SCRIPT)
         foreach(LIBRARY ${ARGN})
@@ -65,7 +68,7 @@ function(target_add_applications TGT_NAME)
             if ("${IS_APPLICATION}" EQUAL "1")
                 #       message(STATUS "${LIBRARY} is an application, adding into linker script")
                 execute_process(
-                    COMMAND python ${CMAKE_SOURCE_DIR}/cmrx/ld/genlink-cmsis.py --add-application 
+                    COMMAND python ${CMRX_ROOT_DIR}/ld/genlink-cmsis.py --add-application 
                         ${OUT_DIR}lib${LIBRARY}.a
                         ${TGT_NAME}
                         ${CMAKE_CURRENT_BINARY_DIR} 


### PR DESCRIPTION
All CMake files expected that CMRX is included in the "cmrx" subdirectory of the project root directory. They failed if the location was different. Set the root of CMRX project as global property and use it wherever path to various tools needs to be used.