### PR TITLE
Put all the kernel source into single library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
-message(STATUS "CMRX root dir: ${CMAKE_CURRENT_SOURCE_DIR}")
+# We do add sources from within foreign directories, so we want the paths
+# absolute.
+# We also add dependencies to targets defined elsewhere.
+cmake_policy(SET CMP0079 NEW)
+cmake_policy(SET CMP0076 NEW)
+
+message(DEBUG "CMRX root dir: ${CMAKE_CURRENT_SOURCE_DIR}")
 set_property(GLOBAL PROPERTY CMRX_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
 include_directories(include)
@@ -17,7 +23,7 @@ endif()
 
 set(HAL_PATH ${CMAKE_CURRENT_SOURCE_DIR}/include/cmrx/arch/${CMRX_ARCH}/${CMRX_HAL})
 get_filename_component(HAL_PATH ${HAL_PATH} ABSOLUTE)
-message(STATUS "HAL path: ${HAL_PATH}")
+message(DEBUG "HAL path: ${HAL_PATH}")
 if (NOT IS_DIRECTORY ${HAL_PATH})
     message(FATAL_ERROR "Architecture ${CMRX_ARCH} does not support HAL ${CMRX_HAL}!")
 endif()

--- a/include/cmrx/os/arch/static.h
+++ b/include/cmrx/os/arch/static.h
@@ -18,7 +18,8 @@
  * Other sections describe port(s) already done.
  *
  * Architecture layer linked to the kernel depends on setting of CMake variable @ref CMRX_ARCH.
- * The architecture layer then forms library named `cmrx_arch` which CMRX automatically links.
+ * The architecture layer updates the `os` target to provide portions which are necessary to 
+ * support desired architecture.
  *
  */
 
@@ -144,10 +145,11 @@ This file has to define two objects:
 Port has to implement certain functions that are expected to be provided by it. Sources of
 the port can be stored in directory `<root_dir>/src/os/arch/<architecture>`. CMRX build
 system will expect that `CMakeLists.txt` file exist there and will include it automatically.
-This `CMakeLists.txt` file shall define one static library named `cmrx_arch`.
-platform-independent part of CMRX will automatically link this library. It can link to
-`cmrx` library to obtain access to certain functions of CMRX kernel that might be usable
-for it.
+This `CMakeLists.txt` file shall update the target `os` to include sources located in the
+architecture support directory. This way the platform-independent portion will be extended
+by the necessary platform support. If platform support requires linking of any additional
+libraries, such as HAL, then commands to let the `os` target link them should be present
+in CMakeLists.txt in this directory as well. 
 
 These sources shall provide implementation of functions outlined in this 
 section of the manual. If port fails to provide the implementation for any of them, build

--- a/man/02_overview.md
+++ b/man/02_overview.md
@@ -730,10 +730,6 @@ defined:
   target you link against it. Therefore you don't have to set up include paths to be able
   to include CMRX headers explicitly.
 
-* library `cmrx_arch` - this library is the architecture dependent portion of CMRX kernel.
-  It is automatically created depending on selected target architecture and HAL being
-  used. Handled automatically by the `os` library. Listed just for reference.
-
 * library `stdlib` - this library contains functions that call system calls. These
   functions are callable from processes. See @ref api to learn on what functions are
   available.

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -1,4 +1,12 @@
-add_subdirectory(arch/${CMRX_ARCH})
+# The order of appearance here is important.
+# While CMake tends to be declarative, in some cases the order of commands matters.
+# You can freely link libraries which were not created yet, but you can't alter
+# properties of libraries which were not created yet.
+# Here the architecture-dependent portion of the kernel will agument the `os` target
+# to provide low level functionality. Due to the circular dependencies between
+# the platform-agnostic and architecture-dependent portion of kernel this is done
+# by modifying the `os` target rather than defining own target.
 add_subdirectory(kernel)
+add_subdirectory(arch/${CMRX_ARCH})
 
 

--- a/src/os/arch/arm/CMakeLists.txt
+++ b/src/os/arch/arm/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(cmrx_arch_SRCS 
+set(cmrx_arm_SRCS 
     static.c 
     mpu.c 
     pendsv.c 
@@ -9,5 +9,5 @@ set(cmrx_arch_SRCS
     syscall.c
 )
 
-add_library(cmrx_arch STATIC ${cmrx_arch_SRCS})
-target_link_libraries(cmrx_arch PUBLIC os cmsis_core_lib)
+target_link_libraries(os PUBLIC cmsis_core_lib)
+target_sources(os PRIVATE ${cmrx_arm_SRCS})

--- a/src/os/kernel/CMakeLists.txt
+++ b/src/os/kernel/CMakeLists.txt
@@ -9,20 +9,9 @@ else()
 endif()
 
 add_library(os STATIC EXCLUDE_FROM_ALL ${os_SRCS})
-target_link_libraries(os PRIVATE cmrx_arch)
 
-# The umbrella library that wraps cross-platform and platform-specific portions of kernel 
-# This is a rather ugly solution to the problem that older versions of CMake can't natively
-# support --start-group and --end-group where it is needed.
-# Thus we create an interface library, which has the command specified verbatim.
-# This thing is most probably extremely fragile and will break in the moment someone else
-# tries to use --end-group with something else.
-add_library(cmrx INTERFACE)
-add_dependencies(cmrx os cmrx_arch)
-target_link_libraries(cmrx INTERFACE "-Wl,--start-group" $<TARGET_FILE:os> $<TARGET_FILE:cmrx_arch> "-Wl,--end-group")
-add_custom_command(OUTPUT ${CMRX_CURRENT_BINARY_DIR}/libcmrx.a
-    COMMAND ${CMAKE_AR_COMMAND} -)
-
+# Just an alias
+add_library(cmrx ALIAS os)
 if (TESTING)
 	set(test_kernel_SRCS tests/test_sched.c)
 	add_executable(test_kernel ${test_kernel_SRCS})

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -9,7 +9,7 @@ if (TESTING)
 endif()
 
 if (NOT CMRX_GDB_PATH)
-    message(STATUS "Path to GDB not set! Skipping tests!")
+    message(STATUS "Path to GDB not set! Skipping tests! Set CMRX_GDB_PATH variable if you want to enable HIL tests.")
     return()
 endif()
 


### PR DESCRIPTION
The previous arrangement with `os` and `cmrx_arch` libraries had issues during linking while both portions were refering to each other. That confused the linker.

Due to the strong coupling of these two portions - CMRX may be a microkernel but this microkernel is a monolith internally - it is better to simply put everything into one single library.