### PR TITLE
Add pico-sdk quirk

### DIFF
--- a/quirks/CMakeLists.txt
+++ b/quirks/CMakeLists.txt
@@ -1,0 +1,10 @@
+if (TARGET pico_stdlib)
+    message(STATUS "Pico SDK detected!")
+
+    if (NOT TARGET cmrx)
+        message(FATAL_ERROR "CMRX target does not exist yet! Include this quirk after CMRX directory has been added!")
+    endif()
+    
+    add_subdirectory(pico-sdk)
+   
+endif()

--- a/quirks/README.md
+++ b/quirks/README.md
@@ -1,0 +1,6 @@
+Quirks to make CMRS run on various HALs
+=======================================
+
+The world is not perfect and various HALs have features which prevent CMRX from being totally multiplatform. This folder contains pieces of code, which are usually HAL or SDK-specific and make CMRX run on that specific hardware.
+
+These are not porting layers nor board support packages. We consider the code here a necessary evil in order for CMRX to run on unmodified vendor SDKs.

--- a/quirks/pico-sdk/CMakeLists.txt
+++ b/quirks/pico-sdk/CMakeLists.txt
@@ -1,0 +1,7 @@
+get_target_property(SRCS pico_standard_link INTERFACE_SOURCES)
+list(FILTER SRCS EXCLUDE REGEX crt0)
+list(APPEND SRCS "${CMAKE_CURRENT_LIST_DIR}/crt0.S")
+message(STATUS "pico_sdlib sources: ${SRCS}")
+set_target_properties(pico_standard_link PROPERTIES INTERFACE_SOURCES "${SRCS}")
+
+

--- a/quirks/pico-sdk/CMakeLists.txt
+++ b/quirks/pico-sdk/CMakeLists.txt
@@ -4,4 +4,4 @@ list(APPEND SRCS "${CMAKE_CURRENT_LIST_DIR}/crt0.S")
 message(STATUS "pico_sdlib sources: ${SRCS}")
 set_target_properties(pico_standard_link PROPERTIES INTERFACE_SOURCES "${SRCS}")
 
-
+target_sources(os PRIVATE ${CMAKE_CURRENT_LIST_DIR}/cmrx_isrs.c)

--- a/quirks/pico-sdk/README.md
+++ b/quirks/pico-sdk/README.md
@@ -1,0 +1,8 @@
+Raspberry Pi Pico SDK quirk
+===========================
+
+The piece of code here is a replacement module which defines interrupt vectors.
+
+This quirk is needed because the way how pico-sdk is organized causes, interrupt vectors can't be overriden by any software which resides in a library. CMRX kernel resides in a library, thus it is affected by this issue.
+
+Thus, we do supply quick & dirty solution to this issue: modified version of crt0.S source from pico-sdk, which has ISRs our kernel is interested in claiming disabled. This solution is far from perfect and actually not sufficient in most applications where application itself wants to claim an ISR. Yet at least it allows us to boot on unmodified recent pico-sdk.

--- a/quirks/pico-sdk/cmrx_isrs.c
+++ b/quirks/pico-sdk/cmrx_isrs.c
@@ -1,0 +1,53 @@
+#define BREAK_ISR(NAME) __attribute__((naked,weak)) void NAME() { asm volatile("BKPT #0\n\t"); }
+
+#define EMPTY_ISR(NAME) __attribute__((weak, alias("__unhandled_user_irq"))) void NAME();
+
+// These interrupt handlers will cause breakpoint to be hit
+BREAK_ISR(isr_invalid)
+BREAK_ISR(NMI_Handler)
+BREAK_ISR(HardFault_Handler)
+BREAK_ISR(SysTick_Handler)
+
+// These handlers are entirely empty, hitting them will cause undefined behavior
+EMPTY_ISR(TIMER_IRQ_0_Handler)
+EMPTY_ISR(TIMER_IRQ_1_Handler)
+EMPTY_ISR(TIMER_IRQ_2_Handler)
+EMPTY_ISR(TIMER_IRQ_3_Handler)
+EMPTY_ISR(PWM_IRQ_WRAP_Handler)
+EMPTY_ISR(USBCTRL_IRQ_Handler)
+EMPTY_ISR(XIP_IRQ_Handler)
+EMPTY_ISR(PIO0_IRQ_0_Handler)
+EMPTY_ISR(PIO0_IRQ_1_Handler)
+EMPTY_ISR(PIO1_IRQ_0_Handler)
+EMPTY_ISR(PIO1_IRQ_1_Handler)
+EMPTY_ISR(DMA_IRQ_0_Handler)
+EMPTY_ISR(DMA_IRQ_1_Handler)
+EMPTY_ISR(IO_IRQ_BANK0_Handler)
+EMPTY_ISR(IO_IRQ_QSPI_Handler)
+EMPTY_ISR(SIO_IRQ_PROC0_Handler)
+EMPTY_ISR(SIO_IRQ_PROC1_Handler)
+EMPTY_ISR(CLOCKS_IRQ_Handler)
+EMPTY_ISR(SPI0_IRQ_Handler)
+EMPTY_ISR(SPI1_IRQ_Handler)
+EMPTY_ISR(UART0_IRQ_Handler)
+EMPTY_ISR(UART1_IRQ_Handler)
+EMPTY_ISR(ADC_IRQ_FIFO_Handler)
+EMPTY_ISR(I2C0_IRQ_Handler)
+EMPTY_ISR(I2C1_IRQ_Handler)
+EMPTY_ISR(RTC_IRQ_Handler)
+EMPTY_ISR(isr_irq26)
+EMPTY_ISR(isr_irq27)
+EMPTY_ISR(isr_irq28)
+EMPTY_ISR(isr_irq29)
+EMPTY_ISR(isr_irq30)
+EMPTY_ISR(isr_irq31)
+
+void __attribute__((naked)) __unhandled_user_irq()
+{
+    asm volatile(
+			".syntax unified\n\t"
+            "MRS R0, IPSR\n\t"
+            "SUBS R0, #16\n\t"
+            "BKPT #0"
+    );
+}

--- a/quirks/pico-sdk/crt0.S
+++ b/quirks/pico-sdk/crt0.S
@@ -93,9 +93,9 @@ __default_isrs_start:
 .endm
 
 // these are separated out for clarity
-decl_isr_bkpt isr_invalid
-decl_isr_bkpt isr_nmi
-decl_isr_bkpt isr_hardfault
+#decl_isr_bkpt isr_invalid
+#decl_isr_bkpt isr_nmi
+#decl_isr_bkpt isr_hardfault
 #decl_isr_bkpt isr_svcall
 #decl_isr_bkpt isr_pendsv
 #decl_isr_bkpt isr_systick
@@ -110,48 +110,48 @@ __default_isrs_end:
 \name:
 .endm
 
-decl_isr isr_irq0
-decl_isr isr_irq1
-decl_isr isr_irq2
-decl_isr isr_irq3
-decl_isr isr_irq4
-decl_isr isr_irq5
-decl_isr isr_irq6
-decl_isr isr_irq7
-decl_isr isr_irq8
-decl_isr isr_irq9
-decl_isr isr_irq10
-decl_isr isr_irq11
-decl_isr isr_irq12
-decl_isr isr_irq13
-decl_isr isr_irq14
-decl_isr isr_irq15
-decl_isr isr_irq16
-decl_isr isr_irq17
-decl_isr isr_irq18
-decl_isr isr_irq19
-decl_isr isr_irq20
-decl_isr isr_irq21
-decl_isr isr_irq22
-decl_isr isr_irq23
-decl_isr isr_irq24
-decl_isr isr_irq25
-decl_isr isr_irq26
-decl_isr isr_irq27
-decl_isr isr_irq28
-decl_isr isr_irq29
-decl_isr isr_irq30
-decl_isr isr_irq31
+#decl_isr isr_irq0
+#decl_isr isr_irq1
+#decl_isr isr_irq2
+#decl_isr isr_irq3
+#decl_isr isr_irq4
+#decl_isr isr_irq5
+#decl_isr isr_irq6
+#decl_isr isr_irq7
+#decl_isr isr_irq8
+#decl_isr isr_irq9
+#decl_isr isr_irq10
+#decl_isr isr_irq11
+#decl_isr isr_irq12
+#decl_isr isr_irq13
+#decl_isr isr_irq14
+#decl_isr isr_irq15
+#decl_isr isr_irq16
+#decl_isr isr_irq17
+#decl_isr isr_irq18
+#decl_isr isr_irq19
+#decl_isr isr_irq20
+#decl_isr isr_irq21
+#decl_isr isr_irq22
+#decl_isr isr_irq23
+#decl_isr isr_irq24
+#decl_isr isr_irq25
+#decl_isr isr_irq26
+#decl_isr isr_irq27
+#decl_isr isr_irq28
+#decl_isr isr_irq29
+#decl_isr isr_irq30
+#decl_isr isr_irq31
 
 // All unhandled USER IRQs fall through to here
-.global __unhandled_user_irq
-.thumb_func
-__unhandled_user_irq:
-    mrs  r0, ipsr
-    subs r0, #16
-.global unhandled_user_irq_num_in_r0
-unhandled_user_irq_num_in_r0:
-    bkpt #0
+#.global __unhandled_user_irq
+#.thumb_func
+#__unhandled_user_irq:
+#    mrs  r0, ipsr
+#    subs r0, #16
+#.global unhandled_user_irq_num_in_r0
+#unhandled_user_irq_num_in_r0:
+#    bkpt #0
 
 // ----------------------------------------------------------------------------
 

--- a/quirks/pico-sdk/crt0.S
+++ b/quirks/pico-sdk/crt0.S
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "pico.h"
+#include "pico/asm_helper.S"
+
+#include "hardware/regs/m0plus.h"
+#include "hardware/regs/addressmap.h"
+#include "hardware/regs/sio.h"
+#include "pico/binary_info/defs.h"
+
+#ifdef NDEBUG
+#ifndef COLLAPSE_IRQS
+#define COLLAPSE_IRQS
+#endif
+#endif
+
+pico_default_asm_setup
+
+.section .vectors, "ax"
+.align 2
+
+.global __vectors, __VECTOR_TABLE
+__VECTOR_TABLE:
+__vectors:
+.word __StackTop
+.word _reset_handler
+.word isr_nmi
+.word isr_hardfault
+.word isr_invalid // Reserved, should never fire
+.word isr_invalid // Reserved, should never fire
+.word isr_invalid // Reserved, should never fire
+.word isr_invalid // Reserved, should never fire
+.word isr_invalid // Reserved, should never fire
+.word isr_invalid // Reserved, should never fire
+.word isr_invalid // Reserved, should never fire
+.word isr_svcall
+.word isr_invalid // Reserved, should never fire
+.word isr_invalid // Reserved, should never fire
+.word isr_pendsv
+.word isr_systick
+.word isr_irq0
+.word isr_irq1
+.word isr_irq2
+.word isr_irq3
+.word isr_irq4
+.word isr_irq5
+.word isr_irq6
+.word isr_irq7
+.word isr_irq8
+.word isr_irq9
+.word isr_irq10
+.word isr_irq11
+.word isr_irq12
+.word isr_irq13
+.word isr_irq14
+.word isr_irq15
+.word isr_irq16
+.word isr_irq17
+.word isr_irq18
+.word isr_irq19
+.word isr_irq20
+.word isr_irq21
+.word isr_irq22
+.word isr_irq23
+.word isr_irq24
+.word isr_irq25
+.word isr_irq26
+.word isr_irq27
+.word isr_irq28
+.word isr_irq29
+.word isr_irq30
+.word isr_irq31
+
+// all default exception handlers do nothing, and we can check for them being set to our
+// default values by seeing if they point to somewhere between __defaults_isrs_start and __default_isrs_end
+.global __default_isrs_start
+__default_isrs_start:
+
+// Declare a weak symbol for each ISR.
+// By default, they will fall through to the undefined IRQ handler below (breakpoint),
+// but can be overridden by C functions with correct name.
+
+.macro decl_isr_bkpt name
+.weak \name
+.type \name,%function
+.thumb_func
+\name:
+    bkpt #0
+.endm
+
+// these are separated out for clarity
+decl_isr_bkpt isr_invalid
+decl_isr_bkpt isr_nmi
+decl_isr_bkpt isr_hardfault
+#decl_isr_bkpt isr_svcall
+#decl_isr_bkpt isr_pendsv
+#decl_isr_bkpt isr_systick
+
+.global __default_isrs_end
+__default_isrs_end:
+
+.macro decl_isr name
+.weak \name
+.type \name,%function
+.thumb_func
+\name:
+.endm
+
+decl_isr isr_irq0
+decl_isr isr_irq1
+decl_isr isr_irq2
+decl_isr isr_irq3
+decl_isr isr_irq4
+decl_isr isr_irq5
+decl_isr isr_irq6
+decl_isr isr_irq7
+decl_isr isr_irq8
+decl_isr isr_irq9
+decl_isr isr_irq10
+decl_isr isr_irq11
+decl_isr isr_irq12
+decl_isr isr_irq13
+decl_isr isr_irq14
+decl_isr isr_irq15
+decl_isr isr_irq16
+decl_isr isr_irq17
+decl_isr isr_irq18
+decl_isr isr_irq19
+decl_isr isr_irq20
+decl_isr isr_irq21
+decl_isr isr_irq22
+decl_isr isr_irq23
+decl_isr isr_irq24
+decl_isr isr_irq25
+decl_isr isr_irq26
+decl_isr isr_irq27
+decl_isr isr_irq28
+decl_isr isr_irq29
+decl_isr isr_irq30
+decl_isr isr_irq31
+
+// All unhandled USER IRQs fall through to here
+.global __unhandled_user_irq
+.thumb_func
+__unhandled_user_irq:
+    mrs  r0, ipsr
+    subs r0, #16
+.global unhandled_user_irq_num_in_r0
+unhandled_user_irq_num_in_r0:
+    bkpt #0
+
+// ----------------------------------------------------------------------------
+
+.section .binary_info_header, "a"
+
+// Header must be in first 256 bytes of main image (i.e. excluding flash boot2).
+// For flash builds we put it immediately after vector table; for NO_FLASH the
+// vectors are at a +0x100 offset because the bootrom enters RAM images directly
+// at their lowest address, so we put the header in the VTOR alignment hole.
+
+#if !PICO_NO_BINARY_INFO
+binary_info_header:
+.word BINARY_INFO_MARKER_START
+.word __binary_info_start
+.word __binary_info_end
+.word data_cpy_table // we may need to decode pointers that are in RAM at runtime.
+.word BINARY_INFO_MARKER_END
+#endif
+
+// ----------------------------------------------------------------------------
+
+.section .reset, "ax"
+
+// On flash builds, the vector table comes first in the image (conventional).
+// On NO_FLASH builds, the reset handler section comes first, as the entry
+// point is at offset 0 (fixed due to bootrom), and VTOR is highly-aligned.
+// Image is entered in various ways:
+//
+// - NO_FLASH builds are entered from beginning by UF2 bootloader
+//
+// - Flash builds vector through the table into _reset_handler from boot2
+//
+// - Either type can be entered via _entry_point by the debugger, and flash builds
+//   must then be sent back round the boot sequence to properly initialise flash
+
+// ELF entry point:
+.type _entry_point,%function
+.thumb_func
+.global _entry_point
+_entry_point:
+
+#if PICO_NO_FLASH
+    // Vector through our own table (SP, VTOR will not have been set up at
+    // this point). Same path for debugger entry and bootloader entry.
+    ldr r0, =__vectors
+#else
+    // Debugger tried to run code after loading, so SSI is in 03h-only mode.
+    // Go back through bootrom + boot2 to properly initialise flash.
+    movs r0, #0
+#endif
+    ldr r1, =(PPB_BASE + M0PLUS_VTOR_OFFSET)
+    str r0, [r1]
+    ldmia r0!, {r1, r2}
+    msr msp, r1
+    bx r2
+
+// Reset handler:
+// - initialises .data
+// - clears .bss
+// - calls runtime_init
+// - calls main
+// - calls exit (which should eventually hang the processor via _exit)
+
+.type _reset_handler,%function
+.thumb_func
+_reset_handler:
+    // Only core 0 should run the C runtime startup code; core 1 is normally
+    // sleeping in the bootrom at this point but check to be sure
+    ldr r0, =(SIO_BASE + SIO_CPUID_OFFSET)
+    ldr r0, [r0]
+    cmp r0, #0
+    bne hold_non_core0_in_bootrom
+
+    // In a NO_FLASH binary, don't perform .data copy, since it's loaded
+    // in-place by the SRAM load. Still need to clear .bss
+#if !PICO_NO_FLASH
+    adr r4, data_cpy_table
+
+    // assume there is at least one entry
+1:
+    ldmia r4!, {r1-r3}
+    cmp r1, #0
+    beq 2f
+    bl data_cpy
+    b 1b
+2:
+#endif
+
+    // Zero out the BSS
+    ldr r1, =__bss_start__
+    ldr r2, =__bss_end__
+    movs r0, #0
+    b bss_fill_test
+bss_fill_loop:
+    stm r1!, {r0}
+bss_fill_test:
+    cmp r1, r2
+    bne bss_fill_loop
+
+platform_entry: // symbol for stack traces
+    // Use 32-bit jumps, in case these symbols are moved out of branch range
+    // (e.g. if main is in SRAM and crt0 in flash)
+    ldr r1, =runtime_init
+    blx r1
+    ldr r1, =main
+    blx r1
+    ldr r1, =exit
+    blx r1
+    // exit should not return.  If it does, hang the core.
+    // (fall thru into our hang _exit impl
+1: // separate label because _exit can be moved out of branch range
+    bkpt #0
+    b 1b
+
+#if !PICO_NO_FLASH
+data_cpy_loop:
+    ldm r1!, {r0}
+    stm r2!, {r0}
+data_cpy:
+    cmp r2, r3
+    blo data_cpy_loop
+    bx lr
+#endif
+
+// Note the data copy table is still included for NO_FLASH builds, even though
+// we skip the copy, because it is listed in binary info
+
+.align 2
+data_cpy_table:
+#if PICO_COPY_TO_RAM
+.word __ram_text_source__
+.word __ram_text_start__
+.word __ram_text_end__
+#endif
+.word __etext
+.word __data_start__
+.word __data_end__
+
+.word __scratch_x_source__
+.word __scratch_x_start__
+.word __scratch_x_end__
+
+.word __scratch_y_source__
+.word __scratch_y_start__
+.word __scratch_y_end__
+
+.word 0 // null terminator
+
+// ----------------------------------------------------------------------------
+// Provide safe defaults for _exit and runtime_init
+// Full implementations usually provided by platform.c
+
+.weak runtime_init
+.type runtime_init,%function
+.thumb_func
+runtime_init:
+    bx lr
+
+// ----------------------------------------------------------------------------
+// If core 1 somehow gets into crt0 due to a spectacular VTOR mishap, we need to
+// catch it and send back to the sleep-and-launch code in the bootrom. Shouldn't
+// happen (it should sleep in the ROM until given an entry point via the
+// cross-core FIFOs) but it's good to be defensive.
+
+hold_non_core0_in_bootrom:
+    ldr r0, = 'W' | ('V' << 8)
+    bl rom_func_lookup
+    bx r0
+
+// ----------------------------------------------------------------------------
+// Stack/heap dummies to set size
+
+// Prior to SDK 1.5.1 these were `.section .stack` without the `, "a"`... Clang linker gives a warning about this,
+// however setting it explicitly to `, "a"` makes GCC *now* discard the section unless it is also KEEP. This
+// seems like very surprising behavior!
+//
+// Strictly the most correct thing to do (as .stack and .heap are unreferenced) is to mark them as "a", and also KEEP, which
+// works correctly for both GCC and Clang, however doing so may break anyone who already has custom linker scripts without
+// the KEEP. Therefore we will only add the "a" on Clang, but will also use KEEP to our own linker scripts.
+
+.macro spacer_section name
+#if PICO_ASSEMBLER_IS_CLANG
+.section \name, "a"
+#else
+.section \name
+#endif
+.endm
+
+spacer_section .stack
+// align to allow for memory protection (although this alignment is pretty much ignored by linker script)
+.p2align 5
+    .equ StackSize, PICO_STACK_SIZE
+.space StackSize
+
+spacer_section .heap
+.p2align 2
+    .equ HeapSize, PICO_HEAP_SIZE
+.space HeapSize


### PR DESCRIPTION
Add quirk, which patches pico-sdk to make it suitable to boot bare CMRX kernel.

All ISRs are defined inside the CMRX kernel handler as weak symbols. This way anyone who needs to hook any ISR can do that from within application library with no issues. The application has to be linked before the CMRX kernel gets linked.