### PR TITLE
Use persistent OpenOCD instead of launching it with each test

### DIFF
--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -18,6 +18,7 @@ function(make_hw_test TEST_DIR)
     set(MAIN_FILE main.c)
     set(HARNESS_FILE debug.c)
     set(GDB_FILE ${CMAKE_CURRENT_LIST_DIR}/debug.gdb)
+    set(OPENOCD_FILE ${CMAKE_SOURCE_DIR}/openocd.cfg)
     set(TEST_APPS "")
 
     # Derive the test name := test directory name
@@ -67,10 +68,12 @@ function(make_hw_test TEST_DIR)
 
     target_link_libraries(${TEST_NAME} test_platform_main)
     message(STATUS "Added test ${TEST_NAME}")
+    message("${CMAKE_CURRENT_LIST_DIR}/gdb.sh ${CMRX_GDB_PATH} ${GDB_FILE} ${OPENOCD_FILE} $<TARGET_FILE:${TEST_NAME}> ${CMAKE_BINARY_DIR}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}")
     add_test(NAME ${TEST_NAME}
-        COMMAND ${CMRX_GDB_PATH} -x ${GDB_FILE} $<TARGET_FILE:${TEST_NAME}>
+        COMMAND ${CMAKE_CURRENT_LIST_DIR}/gdb.sh ${CMRX_GDB_PATH} ${GDB_FILE} ${OPENOCD_FILE} $<TARGET_FILE:${TEST_NAME}> ${CMAKE_BINARY_DIR}
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-    set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 5)
+    set_tests_properties(${TEST_NAME} PROPERTIES TIMEOUT 10)
 endfunction()
 
 message(STATUS "TESTING ENABLED")

--- a/testsuite/debug.gdb
+++ b/testsuite/debug.gdb
@@ -1,5 +1,4 @@
 set $_TEST_STEP = 0
-#target extended-remote | openocd -f openocd.cfg -c "gdb_port pipe"
 target extended-remote localhost:3333
 monitor reset halt
 load

--- a/testsuite/debug.gdb
+++ b/testsuite/debug.gdb
@@ -1,25 +1,26 @@
 set $_TEST_STEP = 0
-target extended-remote | openocd -f openocd.cfg -c "gdb_port pipe"
+#target extended-remote | openocd -f openocd.cfg -c "gdb_port pipe"
+target extended-remote localhost:3333
 monitor reset halt
 load
 
 break TEST_SUCCESS
 commands
-    detach
+    disconnect
 	quit 0
 end
 
 break TEST_FAIL
 commands
     bt
-    detach
+    disconnect
 	quit 1
 end
 
 break TEST_STEP
 commands
     if step != ($_TEST_STEP + 1)
-        detach
+        disconnect
         quit 1
     end
     set $_TEST_STEP = step
@@ -27,4 +28,6 @@ commands
 end
 
 run
+detach
+disconnect
 quit 2

--- a/testsuite/gdb.sh
+++ b/testsuite/gdb.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Usage:
+# gdb <gdb_program> <debug_script> <openocd_script> <target_elf>
+
+echo GDB $1
+echo GDB script $2
+echo OOCD script $3
+echo Text executable $4
+echo Binary directory $5
+
+PID=`cat $5/openocd.pid`
+echo Is OpenOCD running as PID $PID ?
+if ! ps -p $PID > /dev/null 
+then
+    openocd -f $3 &
+    PID=$!
+    echo $PID > $5/openocd.pid
+    disown -h $PID
+else
+    echo OpenOCD already runs as PID $PID
+fi
+
+$1 -x $2 $4

--- a/testsuite/gdb.sh
+++ b/testsuite/gdb.sh
@@ -3,22 +3,61 @@
 # Usage:
 # gdb <gdb_program> <debug_script> <openocd_script> <target_elf>
 
-echo GDB $1
-echo GDB script $2
-echo OOCD script $3
-echo Text executable $4
-echo Binary directory $5
+if [[ $# -lt 5 ]]; then
+    cat << EOF
+Usage:
+$0 <gdb> <gdb_script> <openocd_script> <test_executable> <tmp_dir>
 
-PID=`cat $5/openocd.pid`
-echo Is OpenOCD running as PID $PID ?
-if ! ps -p $PID > /dev/null 
-then
-    openocd -f $3 &
+<gdb>             - path to GDB executable
+<gdb_script>      - path to GDB script driving tests
+<openocd_script>  - path to OpenOCD script
+<text_executable> - path to text binary file (firmware)
+<tmp_dir>         - directory for temporary files (PID file)
+EOF
+    exit 4
+fi
+
+if [ ! -x $1 ]; then
+    echo $1: file is not an executable!
+    exit 3
+fi
+
+if [ ! -f $2 ]; then
+    echo $2: GDB script file does not exist!
+    exit 3
+fi
+
+if [ ! -f $3 ]; then
+    echo $3: OpenOCD script file does not exist!
+    exit 3
+fi
+
+if [ ! -x $4 ]; then
+    echo $4: Test file is not an executable!
+    exit 3
+fi
+
+if [ ! -d $5 ]; then
+    echo $5: Is not a directory!
+    exit 3
+fi
+
+# run_openocd(openocd_script, tmp_dir)
+function run_openocd() {
+    openocd -f $1 &
     PID=$!
-    echo $PID > $5/openocd.pid
+    echo $PID > $2/openocd.pid
     disown -h $PID
+}
+
+if [ ! -f $5/openocd.pid ]; then
+    run_openocd $3 $5
 else
-    echo OpenOCD already runs as PID $PID
+    PID=`cat $5/openocd.pid`
+    if ! ps -p $PID > /dev/null 
+    then
+        run_openocd $3 $5
+    fi
 fi
 
 $1 -x $2 $4


### PR DESCRIPTION
The old approach was to launch OpenOCD in pipe mode with every test. This is quite slow and some probes are not that stable so sustain this. Tests then time out randomly. New approach is to launch OOCD when first test is launched and OpenOCD is not running yet and then to reuse that instance of OpenOCD.