### PR TITLE
Make context switch code portable

### DIFF
--- a/include/cmrx/os/arch/context.h
+++ b/include/cmrx/os/arch/context.h
@@ -1,0 +1,16 @@
+#pragma once
+
+/** @addtogroup arch_arch
+ * @{ 
+ */
+
+/** Request context switch.
+ * This function is called by the platform independent part
+ * of the kernel when @ref cpu_context structure is filled 
+ * with valid data and context switch shall happen.
+ * The implementation of this function should configure the
+ * hardware in a way that context switch will happen as soon
+ * as kernel finishes its work and is ready to return the
+ * CPU back to the userspace code.
+ */
+void os_request_context_switch();

--- a/include/cmrx/os/arch/sched.h
+++ b/include/cmrx/os/arch/sched.h
@@ -17,19 +17,6 @@
  */
 uint32_t * os_thread_populate_stack(int stack_id, unsigned stack_size, entrypoint_t * entrypoint, void * data);
 
-/** Schedule context switch on next suitable moment.
- *
- * This function will tell scheduler, that we want to switch running tasks.
- * Switch itself will be performed on next suitable moment by asynchronous
- * routine. This mechanism is used to avoid context switch in the middle of
- * interrupt routine, or otherwise complicated situation.
- *
- * @param current_task ID of thread which is currently being executed
- * @param next_task ID of thread which should start being executed
- * @returns true if context switch will happen, false otherwise
- */
-bool schedule_context_switch(uint32_t current_task, uint32_t next_task);
-
 /** Create process using process definition.
  * Takes process definition and initializes MPU regions for process out of it.
  * @param process_id ID of process to be initialized

--- a/include/cmrx/os/context.h
+++ b/include/cmrx/os/context.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <stdbool.h>
+#include <cmrx/os/runtime.h>
+
+/** @defgroup os_context Context switching
+ *
+ * @ingroup os
+ *
+ * Kernel internals in support context switching
+ * 
+ * Bulk of the context switching is done inside the platform independent
+ * portion of the kernel, but the final heavy lifting always has to be done
+ * in a platform specific way. The structures defined here help to establish
+ * communication between these two parts of the kernel.
+ */
+
+/** @ingroup os_context
+ * @{
+ */
+
+/** Structure describing upcoming context switch */
+struct OS_scheduling_context_t {
+    struct OS_thread_t * old_task;
+    struct OS_thread_t * new_task;
+
+    struct OS_process_t * old_parent_process;
+    struct OS_process_t * new_parent_process;
+
+    struct OS_process_t * old_host_process;
+    struct OS_process_t * new_host_process;
+
+    uint32_t * new_stack;
+};
+
+/** Schedule context switch on next suitable moment.
+ *
+ * This function will tell scheduler, that we want to switch running tasks.
+ * Switch itself will be performed on next suitable moment by asynchronous
+ * routine. This mechanism is used to avoid context switch in the middle of
+ * interrupt routine, or otherwise complicated situation.
+ *
+ * @param current_task ID of thread which is currently being executed
+ * @param next_task ID of thread which should start being executed
+ * @returns true if context switch will happen, false otherwise
+ */
+bool schedule_context_switch(uint32_t current_task, uint32_t next_task);
+
+/** @} */
+
+extern bool ctxt_switch_pending;
+extern struct OS_scheduling_context_t cpu_context;

--- a/include/cmrx/os/runtime.h
+++ b/include/cmrx/os/runtime.h
@@ -114,7 +114,7 @@ struct OS_thread_t {
  */
 struct OS_stack_t {
 	/** Thread stacks. */
-	unsigned long stacks[OS_STACKS][OS_STACK_DWORD];
+	uint32_t stacks[OS_STACKS][OS_STACK_DWORD];
 
 	/** Information about stack allocation. If n-th bit is set, 
 	 * then n-th stack is allocated. Otherwise it is available. */

--- a/include/cmrx/os/sched.h
+++ b/include/cmrx/os/sched.h
@@ -115,7 +115,7 @@ int os_setpriority(uint8_t priority);
  * @param stack_id ID of stack
  * @returns base address of stack
  */
-unsigned long * os_stack_get(int stack_id);
+uint32_t * os_stack_get(int stack_id);
 
 /** Get thread descriptor.
  * @param thread_id ID of thread

--- a/src/os/arch/arm/pendsv.c
+++ b/src/os/arch/arm/pendsv.c
@@ -4,16 +4,14 @@
  */
 #include <stdint.h>
 #include <cmrx/os/runtime.h>
-#include <cmrx/os/sched.h>
 #include <arch/cortex.h>
 #include <conf/kernel.h>
 
 #include <stdbool.h>
 #include <cmrx/assert.h>
 #include <cmrx/os/sanitize.h>
-#include <cmrx/os/sched.h>
-#include <cmrx/os/signal.h>
 
+#include <cmrx/os/context.h>
 #include <arch/scb.h>
 
 #ifdef KERNEL_HAS_MEMORY_PROTECTION
@@ -21,79 +19,12 @@
 #   include <arch/mpu_priv.h>
 #endif
 
-static struct OS_thread_t * old_task;
-static struct OS_thread_t * new_task;
-
-static struct OS_process_t * old_parent_process;
-static struct OS_process_t * new_parent_process;
-
-static struct OS_process_t * old_host_process;
-static struct OS_process_t * new_host_process;
-
-static uint8_t new_thread_id;
-static Process_t new_process_id;
-static bool ctxt_switch_pending;
-
-extern struct OS_stack_t os_stacks;
-
-/** Opt for task switch.
- * Calling this function will prepare task switch. It will set up
- * some stuff needed and then schedule PendSV.
- * @param current_task ID of task, which is currently running
- * @param next_task ID of task, which should be scheduled next
- * @note API of this function is dumb.
- */
-bool schedule_context_switch(uint32_t current_task, uint32_t next_task)
+void os_request_context_switch()
 {
-	if (ctxt_switch_pending)
-	{
-		// can this be any more robust?
-		return false;
-	}
-
-	ctxt_switch_pending = true;
-
-	old_task = &os_threads[current_task];
-	old_parent_process = &os_processes[old_task->process_id];
-
-	if (old_task->rpc_stack[0] != 0)
-	{
-		old_host_process = &os_processes[old_task->rpc_stack[old_task->rpc_stack[0]]];
-	}
-	else
-	{
-		old_host_process = old_parent_process;
-	}
-
-	if (os_threads[current_task].state == THREAD_STATE_RUNNING)
-	{
-		// only mark leaving thread as ready, if it was runnig before
-		// if leaving thread was, for example, quit before calling
-		// os_sched_yield, then this would return it back to life
-		os_threads[current_task].state = THREAD_STATE_READY;
-	}
-	new_task = &os_threads[next_task];
-	new_parent_process = &os_processes[new_task->process_id];
-	if (new_task->rpc_stack[0] != 0)
-	{
-		new_host_process = &os_processes[new_task->rpc_stack[new_task->rpc_stack[0]]];
-	}
-	else
-	{
-		new_host_process = new_parent_process;
-	}
-
-	new_thread_id = next_task;
-	new_process_id = new_task->process_id;
-
-	os_threads[next_task].state = THREAD_STATE_RUNNING;
-
 	SCB_ICSR |= SCB_ICSR_PENDSVSET;
 
 	__ISB();
 	__DSB();
-
-	return true;
 }
 
 /** Handle task switch.
@@ -113,28 +44,30 @@ __attribute__((naked)) void PendSV_Handler(void)
 	);
 	cortex_disable_interrupts();
 	/* Do NOT put anything here. You will clobber context being stored! */
-	old_task->sp = save_context();
+	cpu_context.old_task->sp = save_context();
 	ctxt_switch_pending = false;
-	sanitize_psp(old_task->sp);
+	sanitize_psp(cpu_context.old_task->sp);
 
 #ifdef KERNEL_HAS_MEMORY_PROTECTION
-	if (old_parent_process != new_parent_process || old_host_process != new_host_process)
+	if (cpu_context.old_parent_process != cpu_context.new_parent_process 
+        || cpu_context.old_host_process != cpu_context.new_host_process)
 	{
 //		mpu_store(&old_host_process->mpu, &old_parent_process->mpu);
-		mpu_restore(&new_host_process->mpu, &new_parent_process->mpu);
+		mpu_restore(&cpu_context.new_host_process->mpu, &cpu_context.new_parent_process->mpu);
 	}
 #endif
 	
 	// Configure stack for incoming process
-	mpu_set_region(OS_MPU_REGION_STACK, &os_stacks.stacks[new_thread_id], sizeof(os_stacks.stacks[new_thread_id]), MPU_RW);
-	sanitize_psp(new_task->sp);
+    // This assumes that all stacks are of same size
+	mpu_set_region(OS_MPU_REGION_STACK, cpu_context.new_stack, sizeof(os_stacks.stacks[0]), MPU_RW);
+	sanitize_psp(cpu_context.new_task->sp);
 
-	if (new_task->signals != 0 && new_task->signal_handler != NULL)
+	if (cpu_context.new_task->signals != 0 && cpu_context.new_task->signal_handler != NULL)
 	{
-		os_deliver_signal(new_task, new_task->signals);
-		new_task->signals = 0;
+		os_deliver_signal(cpu_context.new_task, cpu_context.new_task->signals);
+		cpu_context.new_task->signals = 0;
 	}
-	load_context(new_task->sp);
+	load_context(cpu_context.new_task->sp);
 	/* Do NOT put anything here. You will clobber context just restored! */
 	__ISB();
 	__DSB();

--- a/src/os/kernel/CMakeLists.txt
+++ b/src/os/kernel/CMakeLists.txt
@@ -6,7 +6,14 @@ if (UNIT_TESTING_BUILD)
     add_definitions(-Dstatic=)
 endif()
 
-set(os_SRCS isr.c sched.c signal.c syscall.c timer.c rpc.c)
+set(os_SRCS 
+    context.c
+    isr.c 
+    sched.c 
+    signal.c 
+    syscall.c 
+    timer.c 
+    rpc.c)
 
 add_library(os STATIC EXCLUDE_FROM_ALL ${os_SRCS})
 

--- a/src/os/kernel/context.c
+++ b/src/os/kernel/context.c
@@ -1,0 +1,82 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <cmrx/os/arch/context.h>
+#include <cmrx/os/runtime.h>
+#include <cmrx/os/context.h>
+
+struct OS_scheduling_context_t cpu_context;
+/*static struct OS_thread_t * old_task;
+static struct OS_thread_t * new_task;
+
+static struct OS_process_t * old_parent_process;
+static struct OS_process_t * new_parent_process;
+
+static struct OS_process_t * old_host_process;
+static struct OS_process_t * new_host_process;
+
+static uint32_t * new_stack;*/
+bool ctxt_switch_pending;
+
+extern struct OS_stack_t os_stacks;
+
+/** Schedule context switch on next suitable moment.
+ *
+ * This function will tell scheduler, that we want to switch running tasks.
+ * Switch itself will be performed on next suitable moment by asynchronous
+ * routine. This mechanism is used to avoid context switch in the middle of
+ * interrupt routine, or otherwise complicated situation.
+ *
+ * @param current_task ID of thread which is currently being executed
+ * @param next_task ID of thread which should start being executed
+ * @returns true if context switch will happen, false otherwise
+ */
+bool schedule_context_switch(uint32_t current_task, uint32_t next_task)
+{
+	if (ctxt_switch_pending)
+	{
+		// can this be any more robust?
+		return false;
+	}
+
+	ctxt_switch_pending = true;
+
+	cpu_context.old_task = &os_threads[current_task];
+	cpu_context.old_parent_process = &os_processes[cpu_context.old_task->process_id];
+
+	if (cpu_context.old_task->rpc_stack[0] != 0)
+	{
+		cpu_context.old_host_process = &os_processes[cpu_context.old_task->rpc_stack[cpu_context.old_task->rpc_stack[0]]];
+	}
+	else
+	{
+		cpu_context.old_host_process = cpu_context.old_parent_process;
+	}
+
+	if (os_threads[current_task].state == THREAD_STATE_RUNNING)
+	{
+		// only mark leaving thread as ready, if it was runnig before
+		// if leaving thread was, for example, quit before calling
+		// os_sched_yield, then this would return it back to life
+		os_threads[current_task].state = THREAD_STATE_READY;
+	}
+	cpu_context.new_task = &os_threads[next_task];
+	cpu_context.new_parent_process = &os_processes[cpu_context.new_task->process_id];
+	if (cpu_context.new_task->rpc_stack[0] != 0)
+	{
+		cpu_context.new_host_process = &os_processes[cpu_context.new_task->rpc_stack[cpu_context.new_task->rpc_stack[0]]];
+	}
+	else
+	{
+		cpu_context.new_host_process = cpu_context.new_parent_process;
+	}
+
+    cpu_context.new_stack = os_stacks.stacks[cpu_context.new_task->stack_id];
+
+	os_threads[next_task].state = THREAD_STATE_RUNNING;
+
+    os_request_context_switch();
+
+	return true;
+}
+
+

--- a/src/os/kernel/isr.c
+++ b/src/os/kernel/isr.c
@@ -18,7 +18,7 @@
 #include <conf/kernel.h>
 #include <cmrx/os/runtime.h>
 #include <cmrx/os/sched.h>
-#include <cmrx/os/arch/sched.h>
+#include <cmrx/os/context.h>
 
 void isr_kill(Thread_t thread_id, uint32_t signal)
 {

--- a/src/os/kernel/sched.c
+++ b/src/os/kernel/sched.c
@@ -12,6 +12,7 @@
 #include <cmrx/assert.h>
 #include <cmrx/os/arch/static.h>
 #include <cmrx/os/arch/sched.h>
+#include <cmrx/os/context.h>
 #include <cmrx/os/arch/mpu.h>
 #include <cmrx/os/timer.h>
 #include <cmrx/os/syscalls.h>
@@ -63,7 +64,7 @@ int os_thread_alloc(Process_t process, uint8_t priority);
 bool os_get_next_thread(uint8_t current_thread, uint8_t * next_thread)
 {
 	uint16_t best_prio = PRIORITY_INVALID;
-	uint8_t candidate_thread;
+    uint8_t candidate_thread = 0xFF;
     uint8_t thread = (current_thread + 1) % OS_THREADS;
 
 	uint8_t loops = OS_THREADS;
@@ -233,7 +234,7 @@ int os_stack_create()
 	return STACK_INVALID;
 }
 
-unsigned long * os_stack_get(int stack_id)
+uint32_t * os_stack_get(int stack_id)
 {
     return os_stacks.stacks[stack_id];
 }


### PR DESCRIPTION
Currently the code performing context switch resides in platform support code even if most of it is rather generic and independent on actual platform. The code is split into two parts.

The generic part is moved out into the platform independent part of the kernel. This portion determines pointers to old and new thread and process. It the fills context switch structure and requests context switch.

The platform support part now contains only the heavy lifting part of the code which actually performs the switch.

As a part of this refactor, context switch context has been collected into one structure, instead of many free-standing variables. Just a little housekeeping, no real impact on functionality. Some unused variables have been removed from the context as they were either redundant or entirely unused.