### PR TITLE
Update testing "port" to reflect new switching code

### DIFF
--- a/src/os/arch/testing/pendsv.c
+++ b/src/os/arch/testing/pendsv.c
@@ -1,23 +1,13 @@
+#include <cmrx/os/context.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <cmrx/os/runtime.h>
 
 bool schedule_context_switch_called = false;
 
-bool schedule_context_switch(uint32_t current_task, uint32_t next_task)
+void os_request_context_switch()
 {
-    (void) current_task;
-    (void) next_task;
     schedule_context_switch_called = true;
-	if (os_threads[current_task].state == THREAD_STATE_RUNNING)
-	{
-		// only mark leaving thread as ready, if it was runnig before
-		// if leaving thread was, for example, quit before calling
-		// os_sched_yield, then this would return it back to life
-		os_threads[current_task].state = THREAD_STATE_READY;
-	}
-    os_threads[next_task].state = THREAD_STATE_RUNNING;
-	return true;
+    ctxt_switch_pending = false;
 }
-
 

--- a/src/os/kernel/context.c
+++ b/src/os/kernel/context.c
@@ -15,7 +15,7 @@ static struct OS_process_t * old_host_process;
 static struct OS_process_t * new_host_process;
 
 static uint32_t * new_stack;*/
-bool ctxt_switch_pending;
+bool ctxt_switch_pending = false;
 
 extern struct OS_stack_t os_stacks;
 


### PR DESCRIPTION
Context switching stub is not needed anymore in testing port as the code is now generic and part of the kernel even in unit testing build.

Remove it and create dummy context switch request function that does the mock stuff and pretends that the context switch actually happened.