### PR TITLE
Fix bugs in kernel that cause thread register corruption.

### DIFF
--- a/include/cmrx/arch/arm/cmsis/arch/sysenter.h
+++ b/include/cmrx/arch/arm/cmsis/arch/sysenter.h
@@ -17,7 +17,7 @@
 #define ___SVC(no)\
 	asm volatile(\
 			"SVC %[immediate]\n\t"\
-			"BX LR\n\t" : : [immediate] "I" (no))
+                  "BX LR\n\t" : : [immediate] "I" (no) : "r0")
 
 /** Perform syscall.
  * @param no number of syscall. 

--- a/src/extra/systick.c
+++ b/src/extra/systick.c
@@ -18,13 +18,18 @@ static inline void SysTick_Disable()
 
 void timing_provider_setup(int interval_ms)
 {
+    // We need the PendSV be of the same priority as SysTick.
+    // Otherwise scheduling PendSV from SysTick will fire it 
+    // immediately and that won't do any good to the state of
+    // the program.
+    NVIC_SetPriority(PendSV_IRQn, (1UL << __NVIC_PRIO_BITS) - 1UL);
     SysTick_Config(SystemCoreClock / (interval_ms * 1000));
     // SysTick_Config will enable the systick automatically
     SysTick_Disable();
     systick_us = interval_ms * 1000;
 }
 
-void SysTick_Handler()
+__attribute__((interrupt)) void SysTick_Handler()
 {
     os_sched_timing_callback(systick_us);
 }

--- a/src/os/arch/arm/pendsv.c
+++ b/src/os/arch/arm/pendsv.c
@@ -45,6 +45,13 @@ __attribute__((naked)) void PendSV_Handler(void)
 	cortex_disable_interrupts();
 	/* Do NOT put anything here. You will clobber context being stored! */
 	cpu_context.old_task->sp = save_context();
+
+    // This assert checks that we are not preempting some other interrupt 
+    // handler. If you assert here, then your interrupt handler priority
+    // is messed up. You need to configure PendSV to be the handler with
+    // absolutely the lowest priority.
+    ASSERT(__get_LR() == 0xFFFFFFFDU);
+
 	ctxt_switch_pending = false;
 	sanitize_psp(cpu_context.old_task->sp);
 

--- a/src/os/arch/arm/syscall.c
+++ b/src/os/arch/arm/syscall.c
@@ -23,7 +23,7 @@
  * @param arg2 syscall argument
  * @param arg3 syscall argument
  */
-__attribute__((used)) void SVC_Handler(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
+__attribute__((interrupt)) void SVC_Handler(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
 {
 	uint32_t * psp = (uint32_t *) __get_PSP();
 	sanitize_psp(psp);


### PR DESCRIPTION
Service handlers that don't do special register handling (such as PendSV) were not marked as interrupts, so the compiler did not generate proper prologue and epilogue. This could lead to the corruption of register content if these handlers were executed.

The default CMSIS implementation of SysTick enable routine also does one poorly documented action: it changes the priority of SysTick handler to very low one. This caused that thread switches which were induced by the SysTick (such as round robin thread switching, or threads being resumed from sleep) experienced corrupted register status.

This was due to the PendSV handler preempting SysTick handler rather than being chained after it. The PendSV thus restored registers at the wrong time, causing thread just resumed to crash sooner or later.