### PR TITLE
Use pointers to structures instead of direct access

### DIFF
--- a/include/cmrx/os/runtime.h
+++ b/include/cmrx/os/runtime.h
@@ -67,26 +67,12 @@ struct OS_thread_t {
 	 * and slots which don't have stack allocated yet.
 	 */
 	uint32_t * sp;
-	/** ID of stack, which is allocated to this thread. */
-	uint8_t stack_id;
-
-	/** State of this thread. */
-	enum ThreadState state;
-
 	/** Identification of object, which causes this thread to block.
 	 * This value if context-dependent. If thread is blocked joining other thread,
 	 * then this contains thread ID. If thread is blocked waiting for mutex, then
 	 * this contains mutex address.
 	 */
 	unsigned long block_object;
-
-	/** Ummmmm... */
-	OS_RPC_stack rpc_stack;
-
-	/** Thread priority.
-	 * This is used by scheduler to decide which thread to run.
-	 */
-	uint8_t priority;
 
 	/** Address of signal handler to use.
 	 */
@@ -100,8 +86,23 @@ struct OS_thread_t {
 
 	/** Exit status after thread quit. */
 	int exit_status;
+
+	/** Ummmmm... */
+	OS_RPC_stack rpc_stack;
+
+	/** ID of stack, which is allocated to this thread. */
+	uint8_t stack_id;
+
+	/** State of this thread. */
+	enum ThreadState state;
+
+	/** Thread priority.
+	 * This is used by scheduler to decide which thread to run.
+	 */
+	uint8_t priority;
+
 	/** Owning process reference. */
-	Process_t process_id;
+    Process_t process_id;
 };
 
 #define OS_TASK_NO_STACK		(~0)

--- a/src/os/kernel/isr.c
+++ b/src/os/kernel/isr.c
@@ -22,23 +22,24 @@
 
 void isr_kill(Thread_t thread_id, uint32_t signal)
 {
+    struct OS_thread_t * thread = &os_threads[thread_id];
 	if (thread_id < OS_THREADS
 			&& signal < 32
 			&& (
-				os_threads[thread_id].state == THREAD_STATE_READY
-				|| os_threads[thread_id].state == THREAD_STATE_RUNNING
-				|| os_threads[thread_id].state == THREAD_STATE_STOPPED
+				thread->state == THREAD_STATE_READY
+				|| thread->state == THREAD_STATE_RUNNING
+				|| thread->state == THREAD_STATE_STOPPED
 			   )
 	   )
 	{
-		os_threads[thread_id].signals |= 1 << signal;
-		if (os_threads[thread_id].state == THREAD_STATE_STOPPED)
+		thread->signals |= 1 << signal;
+		if (thread->state == THREAD_STATE_STOPPED)
 		{
-			os_threads[thread_id].state = THREAD_STATE_READY;
+			thread->state = THREAD_STATE_READY;
 		}
 		/* this stuff is dodgy and would deserve complete 
 		 * rewrite to be more robust and more predictable */
-		if (os_threads[thread_id].priority > os_threads[os_get_current_thread()].priority)
+		if (thread->priority > os_threads[os_get_current_thread()].priority)
 		{
 			if (schedule_context_switch(os_get_current_thread(), thread_id))
 			{


### PR DESCRIPTION
This commit performs a refactor of kernel code to use pointers to structures in arrays rather than indexing the array item again and again.

Repeating indexing coding pattern causes that GCC sometimes emits suboptimal and very bulky code.

Items in thread control block were reordered to allow for better packing and less RAM consuption by the kernel.

These changes cause the kernel to be almost 2kB smaller on ARMv6M machine than before. Current fully featured kernel compiles at around 5.5kB. Previously similar build was around 7.5kB.