### PR TITLE
Add support for symmetric multi processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,16 @@
 # We do add sources from within foreign directories, so we want the paths
 # absolute.
 # We also add dependencies to targets defined elsewhere.
+# If any of options defined herein already exists as a variable, then do nothing;
+# This allows users to configure the kernel in their CMakeLists.txt
 cmake_policy(SET CMP0079 NEW)
 cmake_policy(SET CMP0076 NEW)
+cmake_policy(SET CMP0077 NEW)
 
 message(DEBUG "CMRX root dir: ${CMAKE_CURRENT_SOURCE_DIR}")
 set_property(GLOBAL PROPERTY CMRX_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
+include(cmake/options.cmake)
 include(cmake/unit_test_build.cmake)
 
 include_directories(include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ else()
     include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/cmrx/arch/testing)
 
     add_definitions(-DUNIT_TESTING=1)
+    add_definitions(-fpack-struct)
     enable_testing()
     set(CMAKE_C_FLAGS -ggdb3)
 endif()

--- a/README.smp.txt
+++ b/README.smp.txt
@@ -1,0 +1,16 @@
+SMP support readme
+==================
+
+CMRX was designed to support SMP. Support should be minimalistic, but working.
+Unfortunately at the time of writing this support, the hardware debuggers and
+their interface were in pretty bad shape for doing much work with multi-core
+CPUs in SMP mode.
+
+As of now the SMP support is known to be broken if launched on RP2040, the main
+platform on which SMP support was developed (and pretty much the only reasonable
+multi-core microcontroller than mortal human being can get by).
+
+All effort was made to write the code in a way that it won't break running on
+single-core system even if you enable the SMP support.
+
+This may be revisited once more cooperative hardware will be available.

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,0 +1,4 @@
+option(CMRX_ARCH_SMP_SUPPORTED "Architecture supports SMP and project is using it" OFF)
+option(CMRX_OS_NUM_CORES "Amount of cores present in CPU package" INT:1)
+
+set(CMRX_ALL_OPTIONS CMRX_ARCH_SMP_SUPPORTED CMRX_OS_NUM_CORES)

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -1,22 +1,45 @@
 include(CTest)
 
-function(find_tests DIR)
+# Find tests in given directory and process them as HIL tests
+# 
+# This routine will create one HW test for each subdirectory found
+# in given directory. Tests are created based on directory content.
+# See `make_hw_test` for more info.
+#
+# Tests can be augmented with platform file, if platform needs it.
+# This may happen in case of SMP-enabled platform where some primitives
+# need to be provided.
+#
+# Arguments:
+# DIR - directory which contains subdirectories holding tests
+# [PLATFORM_FILE] - optional platform source file included in the build
+function(find_tests DIR) # optionally [PLATFORM_FILE]
     file(GLOB TESTS LIST_DIRECTORIES TRUE CONFIGURE_DEPENDS *)
     foreach(TEST ${TESTS})
         message(STATUS "Assesing ${TEST}")
         if (IS_DIRECTORY ${TEST})
-            make_hw_test(${TEST})
+            make_hw_test(${TEST} ${ARGN})
         endif()
     endforeach()
 endfunction()
 
-function(make_hw_test TEST_DIR)
+# Create HIL test
+#
+# This creates binary for a HIL test. Binary is based on files contained
+# in the root directory from which test search was initiated and from the directory
+# content itself.
+#
+# Arguments:
+# TEST_DIR - directory which contains the test
+# [PLATFORM_FILE] - optional platform source file included into the build of test
+function(make_hw_test TEST_DIR) # optionally [PLATFORM_FILE]
     if ("${CMRX_GDB_PATH}" STREQUAL "")
         message(FATAL_ERROR "variable CMRX_GDB_PATH not set. Tests can't execute")
     endif()
     # Some defaults used if not overriden by test itself
     set(MAIN_FILE main.c)
     set(HARNESS_FILE debug.c)
+    set(PLATFORM_FILE ${ARGN})
     set(GDB_FILE ${CMAKE_CURRENT_LIST_DIR}/debug.gdb)
     set(OPENOCD_FILE ${CMAKE_SOURCE_DIR}/openocd.cfg)
     set(TEST_APPS "")
@@ -52,7 +75,7 @@ function(make_hw_test TEST_DIR)
         return()
     endif()
     message(STATUS "Adding test ${TEST_NAME}")
-    add_firmware(${TEST_NAME} ${MAIN_FILE} ${TEST_FILE} ${HARNESS_FILE})
+    add_firmware(${TEST_NAME} ${MAIN_FILE} ${TEST_FILE} ${HARNESS_FILE} ${PLATFORM_FILE})
     target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
     foreach(APP ${TEST_APPS})

--- a/cmake/unit_test_build.cmake
+++ b/cmake/unit_test_build.cmake
@@ -43,10 +43,24 @@ if (UNIT_TESTING)
             message(WARNING "There is a directory named `tests` in CMRX source tree. Its content is going to be mixed with unit test build. Result is unpredictable!")
         endif()
 
+        # Collect all non-default options
+        set(UT_BUILD_OPTIONS )
+        foreach(CMRX_OPTION ${CMRX_ALL_OPTIONS})
+            message("Examining option ${CMRX_OPTION}")
+            if (DEFINED ${CMRX_OPTION} AND NOT DEFINED CACHE{${CMRX_OPTION}})
+                list(APPEND UT_BUILD_OPTIONS -D${CMRX_OPTION}=${${CMRX_OPTION}})
+                message("Non default value for option ${CMRX_OPTION}")
+            else()
+                message("Option ${CMRX_OPTION} has default value ${${CMRX_OPTION}}")
+            endif()
+        endforeach()
         # Create directory which will host the build and run CMake
         file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
-        execute_process(COMMAND ${CMAKE_COMMAND} -D__UNIT_TESTING_BUILD=1 ${CMAKE_CURRENT_SOURCE_DIR}
+        execute_process(COMMAND ${CMAKE_COMMAND} -D__UNIT_TESTING_BUILD=1 ${UT_BUILD_OPTIONS} ${CMAKE_CURRENT_SOURCE_DIR}
             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+        message(Execute COMMAND ${CMAKE_COMMAND} -D__UNIT_TESTING_BUILD=1 ${UT_BUILD_OPTIONS} ${CMAKE_CURRENT_SOURCE_DIR}
+            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+
 
         # Create targets which jump into the nested build
         # Target to build all tests

--- a/conf/kernel.h
+++ b/conf/kernel.h
@@ -36,4 +36,7 @@
 /** How many sleeping threads can exist */
 #define SLEEPERS_MAX			(2 * OS_THREADS)
 
+#cmakedefine CMRX_ARCH_SMP_SUPPORTED
+#define OS_NUM_CORES    @CMRX_OS_NUM_CORES@
+
 /** @} */

--- a/include/cmrx/application.h
+++ b/include/cmrx/application.h
@@ -15,6 +15,7 @@
 
 //#include "os.h"
 #include <cmrx/os/runtime.h>
+#include <conf/kernel.h>
 #include <stddef.h>
 
 #define __APPL_SYMBOL(application, symbol)	application ## _ ## symbol
@@ -75,12 +76,21 @@ __attribute__((externally_visible, used, section(".applications") )) const struc
  * @param data user-defined data passed to entrypoint function.
  * @param priority thread priority of newly created thread
  */
+#ifdef CMRX_ARCH_SMP_SUPPORTED
+#define OS_THREAD_CREATE(application, entrypoint, data, priority, core) \
+    _OS_THREAD_CREATE(application, entrypoint, data, priority, core)
+#else
 #define OS_THREAD_CREATE(application, entrypoint, data, priority) \
+    _OS_THREAD_CREATE(application, entrypoint, data, priority, 0)
+#endif
+
+#define _OS_THREAD_CREATE(application, entrypoint, data, priority, core) \
 __attribute__((externally_visible, used, section(".thread_create") )) const struct OS_thread_create_t __APPL_SYMBOL(application, thread_create_ ## entrypoint) = {\
 	&__APPL_SYMBOL(application, instance),\
 	entrypoint,\
 	data,\
-	priority\
+	priority,\
+    core\
 }
 
 /** @} */

--- a/include/cmrx/arch/arm/cmsis/arch/conditional.h
+++ b/include/cmrx/arch/arm/cmsis/arch/conditional.h
@@ -51,48 +51,6 @@ ALWAYS_INLINE static inline void __CLREX()
 			);
 }
 
-/** Get value of process SP
- * @return top of application stack
- */
-ALWAYS_INLINE static inline void * __get_PSP(void)
-{
-	void * psp;
-	asm volatile(
-			".syntax unified\n\t"
-			"MRS %0, psp\n\t"
-			: "=r" (psp) 
-			);
-
-	return psp;
-}
-
-/** Get value of process LR
- * @return top of application stack
- */
-ALWAYS_INLINE static inline void * __get_LR(void)
-{
-	void * psp;
-	asm volatile(
-			".syntax unified\n\t"
-			"MOV %0, LR\n\t"
-			: "=r" (psp) 
-			);
-
-	return psp;
-}
-
-/** Set value of process SP
- * @param stack_top new top of application stack
- */
-ALWAYS_INLINE static inline void __set_PSP(unsigned long * stack_top)
-{
-	asm volatile(
-			".syntax unified\n\t"
-			"MSR psp, %0\n\t"
-			: : "r" (stack_top)
-	);
-}
-
 #if 0
 /** Save application context.
  * This function will grab process SP
@@ -142,21 +100,5 @@ ALWAYS_INLINE static inline void load_context(uint32_t * sp)
 	);
 }
 #endif
-
-ALWAYS_INLINE static inline void __set_CONTROL(uint32_t control)
-{
-	asm volatile("MSR control, %0\n" : : "r" (control) : "memory");
-}
-
-ALWAYS_INLINE static inline void __DSB()
-{
-	asm volatile("DSB 0xF\n" : : : "memory");	
-}
-
-ALWAYS_INLINE static inline void __ISB()
-{
-	asm volatile("ISB\n" : : : "memory");	
-//	asm volatile("ISB 0xF\n" : : : "memory");	
-}
 
 /** @} */

--- a/include/cmrx/arch/arm/cmsis/arch/corelocal.h
+++ b/include/cmrx/arch/arm/cmsis/arch/corelocal.h
@@ -1,7 +1,22 @@
 #pragma once
 #include <RTE_Components.h>
 #include CMSIS_device_header
+#include <conf/kernel.h>
 
-#define coreid()	0
-#define OS_NUM_CORES	1
+#ifndef CMRX_ARCH_SMP_SUPPORTED
+    #define coreid()	0
+    #define OS_NUM_CORES	1
 
+#else
+
+/** Callback to get the current CPU core number.
+ * @returns ID of core executing this code. Starts with 0
+ * @note It is implementor's task to provide body of this function as it is heavily HW-dependent.
+ */
+extern unsigned coreid();
+
+#ifndef OS_NUM_CORES
+#error "Macro OS_NUM_CORES is not defined. Use -DOS_NUM_CORES=x to tell the CMRX kernel how many cores it manages!"
+#endif
+
+#endif

--- a/include/cmrx/arch/arm/cmsis/arch/corelocal.h
+++ b/include/cmrx/arch/arm/cmsis/arch/corelocal.h
@@ -4,8 +4,11 @@
 #include <conf/kernel.h>
 
 #ifndef CMRX_ARCH_SMP_SUPPORTED
-    #define coreid()	0
-    #define OS_NUM_CORES	1
+
+#   define coreid()	0
+#   define OS_NUM_CORES	1
+#   define os_smp_lock()
+#   define os_smp_unlock()
 
 #else
 
@@ -14,6 +17,8 @@
  * @note It is implementor's task to provide body of this function as it is heavily HW-dependent.
  */
 extern unsigned coreid();
+extern void os_smp_lock();
+extern void os_smp_unlock();
 
 #ifndef OS_NUM_CORES
 #error "Macro OS_NUM_CORES is not defined. Use -DOS_NUM_CORES=x to tell the CMRX kernel how many cores it manages!"

--- a/include/cmrx/arch/arm/cmsis/arch/corelocal.h
+++ b/include/cmrx/arch/arm/cmsis/arch/corelocal.h
@@ -2,6 +2,10 @@
 #include <RTE_Components.h>
 #include CMSIS_device_header
 #include <conf/kernel.h>
+#include "cortex.h"
+
+#define os_core_lock() __disable_irq()
+#define os_core_unlock() __enable_irq()
 
 #ifndef CMRX_ARCH_SMP_SUPPORTED
 

--- a/include/cmrx/arch/arm/cmsis/arch/cortex.h
+++ b/include/cmrx/arch/arm/cmsis/arch/cortex.h
@@ -291,5 +291,21 @@ static inline ExceptionFrame * pop_exception_frame(ExceptionFrame * frame, unsig
 	return outframe;
 }
 
+/** Get value of process LR
+ * @return top of application stack
+ */
+ALWAYS_INLINE void * __get_LR(void)
+{
+	void * psp;
+	asm volatile(
+			".syntax unified\n\t"
+			"MOV %0, LR\n\t"
+			: "=r" (psp) 
+			);
+
+	return psp;
+}
+
+
 
 /// @}

--- a/include/cmrx/arch/testing/arch/corelocal.h
+++ b/include/cmrx/arch/testing/arch/corelocal.h
@@ -13,6 +13,7 @@
 
 typedef void (*callback_t)();
 extern callback_t cmrx_smp_locked_callback;
+extern callback_t cmrx_smp_unlocked_callback;
 
 
 extern unsigned coreid();

--- a/include/cmrx/arch/testing/arch/corelocal.h
+++ b/include/cmrx/arch/testing/arch/corelocal.h
@@ -2,6 +2,10 @@
 
 #include <conf/kernel.h>
 
+// These do nothing in testing environment
+#define os_core_lock()
+#define os_core_unlock()
+
 #ifndef CMRX_ARCH_SMP_SUPPORTED
 
 #define coreid()	0

--- a/include/cmrx/arch/testing/arch/corelocal.h
+++ b/include/cmrx/arch/testing/arch/corelocal.h
@@ -6,10 +6,18 @@
 
 #define coreid()	0
 #define OS_NUM_CORES 1
+#define os_smp_lock()
+#define os_smp_unlock()
 
 #else
 
+typedef void (*callback_t)();
+extern callback_t cmrx_smp_locked_callback;
+
+
 extern unsigned coreid();
+extern void os_smp_lock();
+extern void os_smp_unlock();
 
 #ifndef OS_NUM_CORES
 #error "Macro OS_NUM_CORES is not defined. Use -DOS_NUM_CORES=x to tell the CMRX kernel how many cores it manages!"

--- a/include/cmrx/arch/testing/arch/corelocal.h
+++ b/include/cmrx/arch/testing/arch/corelocal.h
@@ -1,4 +1,19 @@
 #pragma once
 
+#include <conf/kernel.h>
+
+#ifndef CMRX_ARCH_SMP_SUPPORTED
+
 #define coreid()	0
 #define OS_NUM_CORES 1
+
+#else
+
+extern unsigned coreid();
+
+#ifndef OS_NUM_CORES
+#error "Macro OS_NUM_CORES is not defined. Use -DOS_NUM_CORES=x to tell the CMRX kernel how many cores it manages!"
+#endif
+
+
+#endif

--- a/include/cmrx/assert.h
+++ b/include/cmrx/assert.h
@@ -24,7 +24,7 @@
  */
 #pragma once
 
-#ifndef NDEBUG
+// #ifndef NDEBUG
 
 #ifndef UNIT_TESTING
 /** Evaluate condition and break if it evalues to false.
@@ -47,7 +47,7 @@
 
 #endif
 
-#else
+#if 0
 
 #define ASSERT(cond)
 

--- a/include/cmrx/cmrx.h
+++ b/include/cmrx/cmrx.h
@@ -14,6 +14,16 @@
  * @{
  */
 
-extern void os_start();
+#include <stdint.h>
+#include <conf/kernel.h>
+
+#ifdef CMRX_ARCH_SMP_SUPPORTED
+#   define os_start(core) _os_start((core))
+#else
+#   define os_start() _os_start(0)
+#endif
+
+// Declaring this as noreturn will break HIL tests
+extern void _os_start(uint8_t core);
 
 /** @} */

--- a/include/cmrx/defines.h
+++ b/include/cmrx/defines.h
@@ -32,6 +32,7 @@
 #define E_NOTAVAIL				9
 #define E_INVALID				10
 #define E_IN_TOO_DEEP			11
+#define E_OUT_OF_THREADS        0xFF
 /** @} */
 
 /** Name the null pointer.

--- a/include/cmrx/os/arch/corelocal.h
+++ b/include/cmrx/os/arch/corelocal.h
@@ -40,4 +40,15 @@ void os_smp_lock();
  */
 void os_smp_unlock();
 
+/** Lock the current core
+ * This function ensures that no other code will interrupt the currently running core.
+ * It usually boils down to disabling interrupts.
+ * @note Calling this function does *NOT* prevent another core from running code which
+ * will manipulate kernel data structures. If you want this behavior, use @ref os_smp_lock().
+ */
+void os_core_lock();
 
+/** Unlock the current core
+ * Unlocks exclusive access to the current core. Usually it boils down to enabling interrupts.
+ */
+void os_core_unlock();

--- a/include/cmrx/os/arch/corelocal.h
+++ b/include/cmrx/os/arch/corelocal.h
@@ -1,0 +1,43 @@
+#pragma once
+
+/** @addtogroup arch_arch
+ * @{ 
+ */
+
+/** Provide kernel with identification of current CPU core
+ *
+ * Kernel calls this function if it is configured for SMP. This function
+ * is part of the porting layer but does not need to be implemented in 
+ * port. If the architecture does not provide unified way of determining
+ * which core is the one currently executing this code, then the implementation
+ * of this method may be left to the user.
+ * @returns ID of the currently running code
+ */
+unsigned coreid();
+
+/** Lock the "big kernel lock"
+ *
+ * This function starts the critical section within kernel. Actions that happen
+ * within critical section can ever only happen on one CPU core and other cores
+ * must not motify the same data. Big kernel lock is used to lock thread table,
+ * stack allocation table and sleepers table.
+ *
+ * This function is part of porting layer but depends heavily on target CPU. It
+ * may be left to be implemented by the user. If this function is called, the code
+ * should make sure that if this function is called on any other core before
+ * @ref os_smp_unlock() is called that another call won't proceed.
+ */
+void os_smp_lock();
+
+/** Unlock the "big kernel lock"
+ *
+ * This function ends the critical setion within kernel. 
+ * 
+ * This function is part of the porting layer but depends heavily on target CPU.
+ * It may be left the be implemented by the user. Once this function is called
+ * the code must make sure that any other core potentially being blocked by 
+ * parallel call to @ref os_smp_lock() will be unlocked and continue execution.
+ */
+void os_smp_unlock();
+
+

--- a/include/cmrx/os/ipi.h
+++ b/include/cmrx/os/ipi.h
@@ -1,0 +1,29 @@
+#pragma once
+
+/** Request Inter-processor synchronization.
+ * This is minimalistic implementation for inter-processor synchronization 
+ * request for Cortex-M processors. This implementation does not assume
+ * presence of any inter-processor interrupt mechanism. It assumes that
+ * each core checks for inter-processor sync every now and then.
+ * This function will block until all online cores call os_ipi_sync_probe().
+ * By doing so all cores remain synchronized and it is guarranteed they will
+ * do nothing. Then this function returns.
+ */
+void os_ipi_sync_request();
+
+/** Release cores waiting in inter-processor synchronization loop.
+ * This function will release all cores which are waiting in os_ipi_sync_probe()
+ * function waiting for core which requested synchronization to release it.
+ * Failure to call this function after os_ipi_sync_request() was called will 
+ * result in permanent halt of all other system cores.
+ */
+void os_ipi_sync_release();
+
+/** Check if inter-processor synchronization is requested.
+ * Each core should call this function from time to time. If any other core
+ * calls for inter-processor synchronization, then core calling this function will
+ * be blocked in the call until the core which requested the synchronization doesn't 
+ * release it.
+ */
+void os_ipi_sync_probe();
+

--- a/include/cmrx/os/runtime.h
+++ b/include/cmrx/os/runtime.h
@@ -188,6 +188,9 @@ struct OS_thread_create_t {
 
 	/** Thread priority */
 	uint8_t priority;
+
+    /** Core at which thread should be started */
+    uint8_t core;
 };
 
 /** Scheduler notion on existing threads. */

--- a/include/cmrx/os/sched.h
+++ b/include/cmrx/os/sched.h
@@ -145,4 +145,17 @@ int os_thread_construct(Thread_t tid, entrypoint_t * entrypoint, void * data, ui
  */
 void os_thread_dispose(void);
 
+/** Migrate thread between CPU cores.
+ * This function takes existing thread which is bound to some core 
+ * and moved it over to scheduler queue of another core. In order for this call
+ * to be successful, the thread must already be stopped. If thread is woken up 
+ * by e.g. signal arrived from interrupt service handler via isr_kill() while
+ * this call is in progress then the call will fail.
+ * @param thread_id ID of thread to be migrated
+ * @param target_core ID of core where the thread should be migrated.
+ * @returns E_OK if thread was migrated; E_INVALID if thread is not stopped or call is 
+ * not made from the core at which the thread is currently running.
+ */
+int os_thread_migrate(uint8_t thread_id, int target_core);
+
 /** @} */

--- a/include/cmrx/os/sched.h
+++ b/include/cmrx/os/sched.h
@@ -62,8 +62,9 @@ int os_sched_yield(void);
  * This function populates thread table based on thread autostart macro use.
  * It also creates idle thread with priority 255 and starts scheduler. It never 
  * returns until you have very bad day.
+ * @param [in] start_core number of core for which the kernel is started
  */
-void os_start();
+void _os_start(uint8_t start_core);
 
 /** Configures systick timer.
  *

--- a/include/cmrx/os/sched.h
+++ b/include/cmrx/os/sched.h
@@ -131,11 +131,12 @@ struct OS_thread_t * os_thread_get(Thread_t thread_id);
  * @param tid Thread ID of thread to be constructed
  * @param entrypoint pointer to thread entrypoint function
  * @param data pointer to thread data. pass NULL pointer if no thread data is used
+ * @param core ID of core the thread should run at
  * @returns E_OK if thread was constructed, E_OUT_OF_STACKS if there is no free stack
  * available and E_TASK_RUNNING if thread is not in state suitable for construction
  * (either slot is free, or already constructed).
  */
-int os_thread_construct(Thread_t tid, entrypoint_t * entrypoint, void * data);
+int os_thread_construct(Thread_t tid, entrypoint_t * entrypoint, void * data, uint8_t core);
 
 /** Alias to thread_exit.
  * This is in fact the same function as @ref thread_exit. The only difference is 

--- a/include/cmrx/os/txn.h
+++ b/include/cmrx/os/txn.h
@@ -19,6 +19,9 @@ typedef uint8_t Txn_t;
  * This function will start a transaction. Starting a transaction means that the code
  * will remember actual record version number (active rolling counter value). rolling
  * counters are updated whenever read-write transaction is commited.
+ * @note It is perfectly valid to start transaction and not commit it. This effectively
+ * equals to voluntarily aborting the transaction. Such abandonned transactions pose no 
+ * overhead nor stall / corruption risk.
  * @return transaction ID
  */
 Txn_t os_txn_start();

--- a/include/cmrx/os/txn.h
+++ b/include/cmrx/os/txn.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <stdint.h>
+
+/** @addtogroup os_kernel
+ * @{ 
+ */
+
+/** Type of the transaction performed.
+ */
+enum TxnType {
+    TXN_READONLY, ///< Read-only transaction
+    TXN_READWRITE ///< Read-write transaction
+};
+
+typedef uint8_t Txn_t;
+
+/** Start a transaction.
+ * This function will start a transaction. Starting a transaction means that the code
+ * will remember actual record version number (active rolling counter value). rolling
+ * counters are updated whenever read-write transaction is commited.
+ * @return transaction ID
+ */
+Txn_t os_txn_start();
+
+/** Try to commit the transaction.
+ * This function will try to enter the critical section so that the code running 
+ * afterwards has exclusive access to the shared resource.
+ * If another transaction has been commited meanwhile, then this call will fail
+ * as transaction couldn't be commited. Then the critical section is left
+ * immediately.
+ * If no other transaction conflicted with this one, the code remains in the critical
+ * section and can modify the shared context.
+ * After the code is done with modifying the shared context, it *must* call
+ * @ref os_txn_done which will leave the critical section.
+ * No modification of the shared context is allowed outside of the critical section.
+ * @param [in] transaction the ID of transaction as obtained by the call to @ref ox_txn_start()
+ * @param [in] type the type of transaction
+ * @returns E_OK if transaction can be commited
+ * @returns E_INVALID if transaction cannot be applied as different transaction has been
+ * commited meanwhile.
+ */
+int os_txn_commit(Txn_t transaction, enum TxnType type);
+
+/** Start new transaction and commit it immediately.
+ * This is a combination of @ref os_txn_start and @ref os_txn_commit for special cases
+ * where there is no intermediate computation needed. This is for cases, such as freeing
+ * memory, releasing handles, etc. In these cases no search for free entry or any similar
+ * action has to be done. Just a known-in-advance entry is freed and this change needs
+ * to be transacted.
+ * It will start new transaction and immediately commit it. As this is done atomically,
+ * the commit never fails. This function always returns E_OK, which means that the code
+ * is in commit mode, may change shared data and must call @ref os_txn_done when all 
+ * changes are written.
+ * @returns E_OK as this action never fails.
+ */
+int os_txn_start_commit();
+
+
+/** Finish the transaction commit.
+ * This function will leave the critical section related to the transaction.
+ * This function has to be called for read-write transaction after all the data changes
+ * in the transaction were commited.
+ */
+void os_txn_done();
+
+/** }@ */
+

--- a/include/extra/cm_ipi.h
+++ b/include/extra/cm_ipi.h
@@ -1,0 +1,18 @@
+#pragma once
+/** @defgroup aux_cm_ipi Cortex-M generic IPI provider
+ * @ingroup libs
+ * This is the default provider of IPI for Cortex-M based processors.
+ * This implementation provides the "slow" IPI, which means that there
+ * are no interrupts occupied and implementation relies on all cores
+ * running os_sched_yield() occasionally.
+ * @{
+ */
+
+void os_ipi_sync_request();
+
+void os_ipi_sync_release();
+
+void os_ipi_sync_probe();
+
+/** @} */
+

--- a/include/extra/systick.h
+++ b/include/extra/systick.h
@@ -51,7 +51,7 @@ void timing_provider_setup(int interval_ms);
  */
 void sys_tick_handler();
 
-/** @} */
-
 void timing_provider_schedule(long delay_us);
+
+/** @} */
 

--- a/man/02_overview.md
+++ b/man/02_overview.md
@@ -23,6 +23,7 @@ works
 @subpage hal_integration outlines how SDK libraries and HALs are integrated into
 CMRX-based project.
 
+@subpage smp_support details on specifics of SMP support
 
 @page concepts Basic concepts
 If using CMRX, there are some basic concepts enforced by the kernel itself.
@@ -943,3 +944,15 @@ If necessary CMSIS components are found, then following is done:
   CMSIS core. Only files named according to CMSIS specs are detected. These files are not
   handled automatically, rather it is the integrator's task to handle them in a way the
   vendor SDK is designed to do.
+
+@page smp_support
+
+CMRX kernel supports SMP-aware configuration. If SMP operation is enabled via @ref CMRX_ARCH_SMP_SUPPORTED
+then there are few changes in CMRX behavior:
+
+ * Kernel is started per-core. The prototype of function @ref os_start changes. It now accepts an argument,
+   which denotes, for which core the kernel is being started. This function can't be called from within thread
+   and it won't return. The order in which cores are started is not important, just mind the order in which
+   auto-started threads will begin execution.
+ * Thread auto-starting gets one additional argument which identifies core on which thread is meant to be started.
+ * Additional API @ref os_thread_migrate is provided which allows to migrate thread between cores.

--- a/man/02_overview.md
+++ b/man/02_overview.md
@@ -945,7 +945,7 @@ If necessary CMSIS components are found, then following is done:
   handled automatically, rather it is the integrator's task to handle them in a way the
   vendor SDK is designed to do.
 
-@page smp_support
+@page smp_support SMP support
 
 CMRX kernel supports SMP-aware configuration. If SMP operation is enabled via @ref CMRX_ARCH_SMP_SUPPORTED
 then there are few changes in CMRX behavior:
@@ -956,3 +956,9 @@ then there are few changes in CMRX behavior:
    auto-started threads will begin execution.
  * Thread auto-starting gets one additional argument which identifies core on which thread is meant to be started.
  * Additional API @ref os_thread_migrate is provided which allows to migrate thread between cores.
+
+In SMP arrangement, kernel maintains run queue for each core on which CMRX has been booted. This means that 
+you may have a multicore machine with e.g. 4 cores, run some non-managed code there (such as radio firmware) and
+boot CMRX on three remaining cores. Then you can divide workload between those three cores.
+
+Signal distribution initiated both from thread and ISR currently does not propagate cross-core reliably.

--- a/src/extra/CMakeLists.txt
+++ b/src/extra/CMakeLists.txt
@@ -1,3 +1,7 @@
 set(aux_systick_SRCS systick.c)
 add_library(aux_systick STATIC ${aux_systick_SRCS})
 target_link_libraries(aux_systick cmsis_core_lib cmsis_core)
+
+set(aux_ipi_SRCS cm_ipi.c)
+add_library(aux_ipi STATIC ${aux_ipi_SRCS})
+target_link_libraries(aux_ipi cmsis_core_lib cmsis_core)

--- a/src/extra/cm_ipi.c
+++ b/src/extra/cm_ipi.c
@@ -1,0 +1,59 @@
+#include <cmrx/os/ipi.h>
+#include <arch/corelocal.h>
+#include <conf/kernel.h>
+
+#include <RTE_Components.h>
+#include CMSIS_device_header
+
+#include <stdint.h>
+#include <stdbool.h>
+
+static volatile uint8_t sync_requested = 0;
+static volatile uint8_t sync_cores[OS_NUM_CORES] = {0};
+
+void os_ipi_sync_request()
+{
+    for (unsigned q = 0; q < OS_NUM_CORES; ++q)
+    {
+        sync_cores[q] = 0;
+    }
+    sync_requested = 1;
+    __DSB();
+    sync_cores[coreid()] = 1;
+    __disable_irq();
+    __SEV();
+    bool synced = true;
+    do {
+        synced = true;
+        for (unsigned q = 0; q < OS_NUM_CORES; ++q)
+        {
+            if (sync_cores[q] == 0)
+            {
+                synced = false;
+            }
+        }
+    } while (!synced);
+}
+
+void os_ipi_sync_release()
+{
+    sync_requested = 0;
+    __DSB();
+    __SEV();
+    __enable_irq();
+}
+void os_ipi_sync_probe()
+{
+    if (sync_requested)
+    {
+        __disable_irq();
+        sync_cores[coreid()] = 1;
+        do {
+            __WFE();
+        } while (sync_requested == 1);
+        sync_cores[coreid()] = 0;
+
+        __enable_irq();
+    }
+}
+

--- a/src/os/arch/arm/pendsv.c
+++ b/src/os/arch/arm/pendsv.c
@@ -52,7 +52,6 @@ __attribute__((naked)) void PendSV_Handler(void)
     // absolutely the lowest priority.
     ASSERT(__get_LR() == 0xFFFFFFFDU);
 
-	ctxt_switch_pending = false;
 	sanitize_psp(cpu_context.old_task->sp);
 
 #ifdef KERNEL_HAS_MEMORY_PROTECTION

--- a/src/os/arch/testing/CMakeLists.txt
+++ b/src/os/arch/testing/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(cmrx_testing_SRCS
+    corelocal.c
     static.c
     mpu.c
     sched.c

--- a/src/os/arch/testing/corelocal.c
+++ b/src/os/arch/testing/corelocal.c
@@ -6,7 +6,25 @@ unsigned cmrx_current_core = 0;
 unsigned cmrx_os_smp_locked = 0;
 
 callback_t cmrx_smp_locked_callback = NULL;
+callback_t cmrx_smp_unlocked_callback = NULL;
 
-unsigned coreid() { return cmrx_current_core; }
-void os_smp_lock() { cmrx_os_smp_locked = 1; if (cmrx_smp_locked_callback != NULL) cmrx_smp_locked_callback(); }
-void os_smp_unlock() { cmrx_os_smp_locked = 0; }
+unsigned coreid() 
+{ 
+    return cmrx_current_core; 
+}
+
+void os_smp_lock() { 
+    cmrx_os_smp_locked = 1; 
+    if (cmrx_smp_locked_callback != NULL) 
+    {
+        cmrx_smp_locked_callback(); 
+    }
+}
+
+void os_smp_unlock() { 
+    cmrx_os_smp_locked = 0; 
+    if (cmrx_smp_unlocked_callback != NULL)
+    {
+        cmrx_smp_unlocked_callback();
+    }
+}

--- a/src/os/arch/testing/corelocal.c
+++ b/src/os/arch/testing/corelocal.c
@@ -1,6 +1,7 @@
 #include <arch/corelocal.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 unsigned cmrx_current_core = 0;
 unsigned cmrx_os_smp_locked = 0;
@@ -14,6 +15,13 @@ unsigned coreid()
 }
 
 void os_smp_lock() { 
+    if (cmrx_os_smp_locked)
+    {
+        printf("\nFATAL ERROR: Attempt to lock BKL while already locked!\n");
+        // Attempt to lock recursively!
+        abort();
+    }
+//    printf("\nBKL lock!");
     cmrx_os_smp_locked = 1; 
     if (cmrx_smp_locked_callback != NULL) 
     {
@@ -22,6 +30,13 @@ void os_smp_lock() {
 }
 
 void os_smp_unlock() { 
+    if (!cmrx_os_smp_locked)
+    {
+        printf("\nFATAL ERROR: Attempt to unlock BKL while not locked!\n");
+        // Attempt to unlock when no lock is locked!
+        abort();
+    }
+//    printf("\nBKL unlock!");
     cmrx_os_smp_locked = 0; 
     if (cmrx_smp_unlocked_callback != NULL)
     {

--- a/src/os/arch/testing/corelocal.c
+++ b/src/os/arch/testing/corelocal.c
@@ -1,5 +1,12 @@
 #include <arch/corelocal.h>
+#include <stddef.h>
+#include <stdio.h>
 
 unsigned cmrx_current_core = 0;
+unsigned cmrx_os_smp_locked = 0;
+
+callback_t cmrx_smp_locked_callback = NULL;
 
 unsigned coreid() { return cmrx_current_core; }
+void os_smp_lock() { cmrx_os_smp_locked = 1; if (cmrx_smp_locked_callback != NULL) cmrx_smp_locked_callback(); }
+void os_smp_unlock() { cmrx_os_smp_locked = 0; }

--- a/src/os/arch/testing/corelocal.c
+++ b/src/os/arch/testing/corelocal.c
@@ -8,6 +8,7 @@ unsigned cmrx_os_smp_locked = 0;
 
 callback_t cmrx_smp_locked_callback = NULL;
 callback_t cmrx_smp_unlocked_callback = NULL;
+callback_t cmrx_smp_wrong_lock_callback = NULL;
 
 unsigned coreid() 
 { 
@@ -17,9 +18,14 @@ unsigned coreid()
 void os_smp_lock() { 
     if (cmrx_os_smp_locked)
     {
-        printf("\nFATAL ERROR: Attempt to lock BKL while already locked!\n");
-        // Attempt to lock recursively!
-        abort();
+        if (cmrx_smp_wrong_lock_callback) {
+            cmrx_smp_wrong_lock_callback();
+            return;
+        } else {
+            printf("\nFATAL ERROR: Attempt to lock BKL while already locked!\n");
+            // Attempt to lock recursively!
+            abort();
+        }
     }
 //    printf("\nBKL lock!");
     cmrx_os_smp_locked = 1; 
@@ -32,9 +38,14 @@ void os_smp_lock() {
 void os_smp_unlock() { 
     if (!cmrx_os_smp_locked)
     {
-        printf("\nFATAL ERROR: Attempt to unlock BKL while not locked!\n");
-        // Attempt to unlock when no lock is locked!
-        abort();
+        if (cmrx_smp_wrong_lock_callback) {
+            cmrx_smp_wrong_lock_callback();
+            return;
+        } else {
+            printf("\nFATAL ERROR: Attempt to unlock BKL while not locked!\n");
+            // Attempt to unlock when no lock is locked!
+            abort();
+        }
     }
 //    printf("\nBKL unlock!");
     cmrx_os_smp_locked = 0; 

--- a/src/os/arch/testing/corelocal.c
+++ b/src/os/arch/testing/corelocal.c
@@ -1,0 +1,5 @@
+#include <arch/corelocal.h>
+
+unsigned cmrx_current_core = 0;
+
+unsigned coreid() { return cmrx_current_core; }

--- a/src/os/arch/testing/pendsv.c
+++ b/src/os/arch/testing/pendsv.c
@@ -8,6 +8,6 @@ bool schedule_context_switch_called = false;
 void os_request_context_switch()
 {
     schedule_context_switch_called = true;
-    ctxt_switch_pending = false;
+//    ctxt_switch_pending = false;
 }
 

--- a/src/os/kernel/CMakeLists.txt
+++ b/src/os/kernel/CMakeLists.txt
@@ -17,6 +17,8 @@ set(os_SRCS
     rpc.c)
 
 add_library(os STATIC EXCLUDE_FROM_ALL ${os_SRCS})
+get_property(CMRX_ROOT_DIR GLOBAL PROPERTY CMRX_ROOT_DIR)
+target_include_directories(os INTERFACE ${CMRX_ROOT_DIR}/include ${CMAKE_BINARY_DIR} ${HAL_PATH})
 
 # Just an alias
 add_library(cmrx ALIAS os)

--- a/src/os/kernel/CMakeLists.txt
+++ b/src/os/kernel/CMakeLists.txt
@@ -13,6 +13,7 @@ set(os_SRCS
     signal.c 
     syscall.c 
     timer.c 
+    txn.c
     rpc.c)
 
 add_library(os STATIC EXCLUDE_FROM_ALL ${os_SRCS})

--- a/src/os/kernel/context.c
+++ b/src/os/kernel/context.c
@@ -15,7 +15,7 @@ static struct OS_process_t * old_host_process;
 static struct OS_process_t * new_host_process;
 
 static uint32_t * new_stack;*/
-bool ctxt_switch_pending = false;
+//bool ctxt_switch_pending = false;
 
 extern struct OS_stack_t os_stacks;
 
@@ -32,13 +32,17 @@ extern struct OS_stack_t os_stacks;
  */
 bool schedule_context_switch(uint32_t current_task, uint32_t next_task)
 {
-	if (ctxt_switch_pending)
+// This is probably useless with transactions now
+#if 0
+
+    if (ctxt_switch_pending)
 	{
 		// can this be any more robust?
 		return false;
 	}
 
 	ctxt_switch_pending = true;
+#endif
 
 	cpu_context.old_task = &os_threads[current_task];
 	cpu_context.old_parent_process = &os_processes[cpu_context.old_task->process_id];

--- a/src/os/kernel/sched.c
+++ b/src/os/kernel/sched.c
@@ -223,17 +223,24 @@ int os_idle_thread(void * data)
 int os_stack_create()
 {
 	uint32_t stack_mask = 1;
+    int rv = STACK_INVALID;
+
+    os_smp_lock();
+
 	for(int q = 0; q < OS_STACKS; ++q)
 	{
 		if ((os_stacks.allocations & stack_mask) == 0)
 		{
 			os_stacks.allocations |= stack_mask;
-			return q;
+			rv = q;
+            break;
 		}
 		stack_mask *= 2;
 	}
 
-	return STACK_INVALID;
+    os_smp_unlock();
+
+	return rv;
 }
 
 uint32_t * os_stack_get(int stack_id)

--- a/src/os/kernel/sched.c
+++ b/src/os/kernel/sched.c
@@ -255,7 +255,9 @@ void os_stack_dispose(uint32_t stack_id)
 {
 	if (stack_id < OS_STACKS)
 	{
+        os_smp_lock();
 		os_stacks.allocations &= ~(1 << stack_id);
+        os_smp_unlock();
 	}
 }
 

--- a/src/os/kernel/syscall.c
+++ b/src/os/kernel/syscall.c
@@ -45,7 +45,6 @@ static const struct Syscall_Entry_t syscalls[] = {
 
 int os_system_call(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3, uint8_t syscall_id)
 {
-	ASSERT(syscall_id < (sizeof(syscalls) / sizeof(syscalls[0])));
 	for (unsigned q = 0; q < (sizeof(syscalls) / sizeof(syscalls[0])); ++q)
 	{
 		if (syscalls[q].id == syscall_id)

--- a/src/os/kernel/tests/CMakeLists.txt
+++ b/src/os/kernel/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(test_kernel_SRCS
     rpc_stack_push.c
     rpc_stack_pop.c
     os_sched_timing_callback.c
+    os_txn.c
     )
 
 

--- a/src/os/kernel/tests/CMakeLists.txt
+++ b/src/os/kernel/tests/CMakeLists.txt
@@ -15,8 +15,15 @@ set(test_kernel_SRCS
     rpc_stack_pop.c
     os_sched_timing_callback.c
     )
+
+
 add_executable(test_kernel ${test_kernel_SRCS})
 target_link_libraries(test_kernel os ctest)
+
+# The following tests are only supported if SMP is enabled
+if (CMRX_ARCH_SMP_SUPPORTED)
+    target_sources(test_kernel PRIVATE os_thread_migrate.c)
+endif()
 
 add_test(NAME test_kernel COMMAND test_kernel)
 

--- a/src/os/kernel/tests/CMakeLists.txt
+++ b/src/os/kernel/tests/CMakeLists.txt
@@ -22,7 +22,11 @@ target_link_libraries(test_kernel os ctest)
 
 # The following tests are only supported if SMP is enabled
 if (CMRX_ARCH_SMP_SUPPORTED)
-    target_sources(test_kernel PRIVATE os_thread_migrate.c)
+    target_sources(test_kernel PRIVATE 
+        os_thread_migrate.c
+        background_checker.c
+        smp_atomic_ops.c
+        )
 endif()
 
 add_test(NAME test_kernel COMMAND test_kernel)

--- a/src/os/kernel/tests/background_checker.c
+++ b/src/os/kernel/tests/background_checker.c
@@ -2,6 +2,7 @@
 
 #include <memory.h>
 #include <string.h>
+#include <stdio.h>
 
 int _checker_main(void * _d)
 {
@@ -32,6 +33,21 @@ int _checker_main(void * _d)
         memcpy(buf, checker->data, checker->data_size);
 
         if (memcmp(buf, &checker->templ[cursor * checker->data_size], checker->data_size) != 0) {
+            if (result != DataMismatch)
+            {
+                printf("\nTemplate data does not match the actual data in sample %d!\nExpected:", cursor);
+                for (int q = 0; q < checker->data_size; ++q)
+                {
+                    printf(" %02hhX", checker->templ[cursor * checker->data_size + q]);
+                }
+                printf("\nActual:  ");
+                for (int q = 0; q < checker->data_size; ++q)
+                {
+                    printf(" %02hhX", buf[q]);
+                }
+                printf("\n");
+                abort();
+            }
             result = DataMismatch;
         }
 
@@ -39,6 +55,7 @@ int _checker_main(void * _d)
 
     if (cursor != checker->templ_count - 1)
     {
+        printf("\nTemplate contains different amount of samples than were seen in the test (expected %d, seen %d)!\n", checker->templ_count, cursor + 1);
         result = LockCountMismatch;
     }
 

--- a/src/os/kernel/tests/background_checker.c
+++ b/src/os/kernel/tests/background_checker.c
@@ -1,0 +1,163 @@
+#include "background_checker.h"
+
+#include <memory.h>
+#include <string.h>
+
+int _checker_main(void * _d)
+{
+    struct checker_t * checker = (struct checker_t *) _d;
+    char * buf = malloc(checker->data_size);
+    memset(buf, 0, checker->data_size);
+
+    int result = OK;
+    bool unlock_barrier = true;
+    unsigned cursor = 0;
+
+    while (checker->running) {
+        if (*checker->semaphore != 0) {
+            if (unlock_barrier)
+            {
+                unlock_barrier = false;
+                cursor++;
+                barrier_release(checker->barrier);
+            }
+            // semaphore active
+            continue;
+        }
+        if (cursor >= checker->templ_count)
+        {
+            // Skip comparing further data, just release barriers so the main thread
+            // doesn't get blocked by us
+            result = LockCountMismatch;
+            continue;
+        }
+        unlock_barrier = true;
+
+        memcpy(buf, checker->data, checker->data_size);
+
+        if (memcmp(buf, &checker->templ[cursor * checker->data_size], checker->data_size) != 0) {
+            result = DataMismatch;
+        }
+
+    }
+
+    if (cursor != checker->templ_count - 1)
+    {
+        result = LockCountMismatch;
+    }
+
+    return result;
+}
+
+
+struct checker_t * checker_create(void * data, void * templ, size_t data_size, size_t templ_count, unsigned * semaphore, struct barrier_t * barrier) 
+{
+    if (data == NULL || templ == NULL || semaphore == NULL || barrier == NULL)
+    {
+        return NULL;
+    }
+
+    struct checker_t * checker = malloc(sizeof(struct checker_t));
+    
+    if (checker == NULL) {
+        return checker;
+    }
+
+    checker->data = data;
+    checker->templ = templ;
+    checker->data_size = data_size;
+    checker->templ_count = templ_count;
+    checker->semaphore = semaphore;
+    checker->running = true;
+    checker->result = true;
+    checker->barrier = barrier;
+
+    int rv = thrd_create(&checker->thread, _checker_main, checker);
+
+    if (rv != thrd_success)
+    {
+        free(checker);
+        return NULL;
+    }
+
+    return checker;
+}
+
+enum eCheckerResult checker_finish(struct checker_t *checker)
+{
+    if (checker == NULL)
+    {
+        return InternalError;
+    }
+
+    if (checker->running == false)
+    {
+        thrd_join(checker->thread, NULL);
+        free(checker);
+        return InternalError;
+    }
+
+    checker->running = false;
+
+    int rv = 0;
+
+    thrd_join(checker->thread, &rv);
+
+    free(checker);
+
+    return rv;
+}
+
+struct barrier_t * barrier_create() 
+{
+    struct barrier_t * barrier = malloc(sizeof(struct barrier_t));
+    
+    if (barrier == NULL) {
+        return barrier;
+    }
+
+    int rv = mtx_init(&barrier->mutex, mtx_plain);
+
+    if (rv != thrd_success)
+    {
+        free(barrier);
+        return NULL;
+    }
+    
+    rv = cnd_init(&barrier->cv);
+
+    if (rv != thrd_success)
+    {
+        mtx_destroy(&barrier->mutex);
+        free(barrier);
+        return NULL;
+    }
+
+    mtx_lock(&barrier->mutex);
+
+    return barrier;
+}
+
+bool barrier_wait(struct barrier_t * barrier)
+{
+    if (barrier == NULL)
+    {
+        return false;
+    }
+
+    cnd_wait(&barrier->cv, &barrier->mutex);
+
+    return true;
+}
+
+bool barrier_release(struct barrier_t * barrier)
+{
+    if (barrier == NULL)
+    {
+        return false;
+    }
+
+    cnd_signal(&barrier->cv);
+
+    return true;
+}

--- a/src/os/kernel/tests/background_checker.c
+++ b/src/os/kernel/tests/background_checker.c
@@ -2,7 +2,6 @@
 
 #include <memory.h>
 #include <string.h>
-#include <stdio.h>
 
 int _checker_main(void * _d)
 {

--- a/src/os/kernel/tests/background_checker.h
+++ b/src/os/kernel/tests/background_checker.h
@@ -14,7 +14,8 @@ struct checker_t {
     size_t data_size;
     size_t templ_count;
     unsigned * semaphore;
-    struct barrier_t * barrier;
+    struct barrier_t * lock_barrier;
+    struct barrier_t * unlock_barrier;
     bool running;
     bool result;
 };
@@ -39,7 +40,7 @@ enum eCheckerResult {
  * Check is suspended if semaphore has non-zero value. This allows to emulate
  * atomic behavior.
  */
-struct checker_t * checker_create(void * data, void * templ, size_t data_size, size_t templ_count, unsigned * semaphore, struct barrier_t * barrier);
+struct checker_t * checker_create(void * data, void * templ, size_t data_size, size_t templ_count, unsigned * semaphore);
 
 /** Finish checker run.
  * @returns return value of checker run:
@@ -69,4 +70,8 @@ bool barrier_wait(struct barrier_t * barrier);
  * nothing.
  */
 bool barrier_release(struct barrier_t * barrier);
+
+/** Free barrier object.
+ */
+void barrier_free(struct barrier_t * barrier);
 

--- a/src/os/kernel/tests/background_checker.h
+++ b/src/os/kernel/tests/background_checker.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <threads.h>
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+struct barrier_t;
+
+struct checker_t {
+    thrd_t thread;
+    void * data;
+    char * templ;
+    size_t data_size;
+    size_t templ_count;
+    unsigned * semaphore;
+    struct barrier_t * barrier;
+    bool running;
+    bool result;
+};
+
+/** Type to hold barrier used to synchronize normal code and checker.
+ */
+struct barrier_t {
+    mtx_t mutex;
+    cnd_t cv;
+};
+
+enum eCheckerResult {
+    OK = 0,
+    DataMismatch,
+    LockCountMismatch,
+    InternalError
+};
+
+/** Creates atomicity checker.
+ * Takes pointer to @ref data_size sized data. It then periodically checks
+ * if the data is of an expected format.
+ * Check is suspended if semaphore has non-zero value. This allows to emulate
+ * atomic behavior.
+ */
+struct checker_t * checker_create(void * data, void * templ, size_t data_size, size_t templ_count, unsigned * semaphore, struct barrier_t * barrier);
+
+/** Finish checker run.
+ * @returns return value of checker run:
+ * OK if all samples checked matched and every sample was checked
+ * DataMismatch if any of samples was not as specified by the template
+ * LockCountMismatch if amount of lock events does not match amount of samples - 1
+ * InternalError if there was memory allocation error or checker was already stopped when function was called
+ */
+enum eCheckerResult checker_finish(struct checker_t * checker);
+
+/** Create synchronization barrier object.
+ * This object may be used to synchronize two threads. Thread which created the barrier
+ * can call @ref barrier_wait to wait for someone else to unblock it.
+ * @returns barrier object or NULL pointer if creation failed
+ */
+struct barrier_t * barrier_create();
+
+/** Wait on barrier to be unlocked.
+ * This call can be used from thread which created the barrier object only. It will
+ * force the calling thread to wait until another thread unblocks it. This is used
+ * to synchronize main thread and checker thread.
+ */
+bool barrier_wait(struct barrier_t * barrier);
+
+/** Unblock barrier.
+ * If anyone is waiting on barrier, then this will unblock it. Otherwise it does 
+ * nothing.
+ */
+bool barrier_release(struct barrier_t * barrier);
+

--- a/src/os/kernel/tests/background_checker.h
+++ b/src/os/kernel/tests/background_checker.h
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#define ARR_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+
 struct barrier_t;
 
 struct checker_t {

--- a/src/os/kernel/tests/os_start.c
+++ b/src/os/kernel/tests/os_start.c
@@ -1,8 +1,15 @@
+#include <cmrx/cmrx.h>
 #include <cmrx/os/sched.h>
 
 #undef NULL
 #include <ctest.h>
 #include <string.h>
+
+#ifdef CMRX_ARCH_SMP_SUPPORTED
+#define CORE_ZERO   0
+#else
+#define CORE_ZERO
+#endif
 
 #define _ptr(x)	((void *) (x))
 extern void provide_process_table(struct OS_process_definition_t * table, unsigned count);
@@ -40,7 +47,7 @@ CTEST2(os_start, process)
 
 	provide_process_table(ptable, 1);
 
-	os_start();
+	os_start(CORE_ZERO);
 	ASSERT_EQUAL((long) os_processes[0].definition, (long) &ptable[0]);
 	ASSERT_EQUAL(0, os_threads[0].process_id);
 	ASSERT_EQUAL(0, os_threads[1].priority);
@@ -85,7 +92,7 @@ CTEST2(os_start, thread)
 
 	provide_thread_table(ttable, 1);
 
-	os_start();
+	os_start(CORE_ZERO);
 
 	ASSERT_EQUAL((long) os_processes[0].definition, (long) &ptable[0]);
 

--- a/src/os/kernel/tests/os_thread_migrate.c
+++ b/src/os/kernel/tests/os_thread_migrate.c
@@ -1,0 +1,94 @@
+#include "cmrx/defines.h"
+#include <cmrx/os/sched.h>
+#include <ctest.h>
+#include <string.h>
+#include <arch/corelocal.h>
+
+// These tests can only be executed on systems which have more than
+// one physical core in SMP. On other systems, the necessary structures
+// are not present in the kernel.
+
+// Kernel private functions and variables, not part of any header
+extern struct OS_core_state_t core[OS_NUM_CORES];
+
+extern int os_stack_create();
+extern int os_thread_exit(int status);
+extern int os_thread_migrate(uint8_t thread_id, int status);
+extern bool schedule_context_switch_called;
+extern unsigned cmrx_current_core;
+
+CTEST_DATA(os_thread_migrate) {
+};
+
+CTEST_SETUP(os_thread_migrate) {
+    memset(&os_stacks, 0, sizeof(os_stacks));
+    memset(&os_threads, 0, sizeof(os_threads));
+
+    os_threads[0].priority = 32;
+    os_threads[1].priority = 32;
+    os_threads[2].priority = 16;
+    os_threads[3].priority = 64;
+    os_threads[4].priority = 64;
+
+    os_threads[0].core_id = 0;
+    os_threads[1].core_id = 0;
+    os_threads[2].core_id = 0;
+    os_threads[3].core_id = 0;
+    os_threads[4].core_id = 1;
+
+    os_threads[0].state = THREAD_STATE_RUNNING;
+    os_threads[1].state = THREAD_STATE_STOPPED;
+    os_threads[2].state = THREAD_STATE_EMPTY;
+    os_threads[3].state = THREAD_STATE_FINISHED;
+    os_threads[4].state = THREAD_STATE_RUNNING;
+
+    os_threads[0].stack_id = os_stack_create();
+    os_threads[1].stack_id = os_stack_create();
+    os_threads[4].stack_id = os_stack_create();
+
+    schedule_context_switch_called = false;
+    core[0].thread_current = 0;
+    core[1].thread_current = 4;
+
+}
+
+CTEST2(os_thread_migrate, clean_migration_stopped_thread) {
+    cmrx_current_core = 0;
+
+    int return_value = os_thread_migrate(1, 1);
+    ASSERT_EQUAL(os_threads[1].state, THREAD_STATE_MIGRATING);
+    ASSERT_EQUAL(os_threads[1].core_id, 1);
+
+    os_thread_continue(1);
+    ASSERT_EQUAL(os_threads[1].state, THREAD_STATE_READY);
+    ASSERT_EQUAL(os_threads[1].core_id, 1);
+}
+
+CTEST2(os_thread_migrate, rejected_migration_empty_thread) {
+    cmrx_current_core = 0;
+
+    int return_value = os_thread_migrate(2, 1);
+    ASSERT_EQUAL(return_value, E_INVALID);
+    ASSERT_EQUAL(os_threads[2].state, THREAD_STATE_EMPTY);
+    ASSERT_EQUAL(os_threads[2].core_id, 0);
+}
+
+CTEST2(os_thread_migrate, rejected_migration_foreign_thread) {
+    cmrx_current_core = 0;
+
+    // Attempt to migrate thread running on different core to local core
+    int return_value = os_thread_migrate(4, 0);
+
+    ASSERT_EQUAL(return_value, E_INVALID);
+    ASSERT_EQUAL(os_threads[4].core_id, 1);
+    ASSERT_EQUAL(os_threads[4].state, THREAD_STATE_RUNNING);
+}
+
+CTEST2(os_thread_migrate, rejected_migration_running_thread) {
+    cmrx_current_core = 0;
+
+    int return_value = os_thread_migrate(0, 1);
+    ASSERT_EQUAL(return_value, E_INVALID);
+    ASSERT_EQUAL(os_threads[1].state, THREAD_STATE_RUNNING);
+    ASSERT_EQUAL(os_threads[1].core_id, 0);
+}

--- a/src/os/kernel/tests/os_thread_migrate.c
+++ b/src/os/kernel/tests/os_thread_migrate.c
@@ -17,11 +17,6 @@ extern int os_thread_migrate(uint8_t thread_id, int status);
 extern bool schedule_context_switch_called;
 extern unsigned cmrx_current_core;
 
-int os_thread_migrate(uint8_t, int)
-{
-    return 0;
-}
-
 CTEST_DATA(os_thread_migrate) {
 };
 
@@ -61,7 +56,7 @@ CTEST2(os_thread_migrate, clean_migration_stopped_thread) {
     cmrx_current_core = 0;
 
     int return_value = os_thread_migrate(1, 1);
-    ASSERT_EQUAL(return_value, E_INVALID);
+    ASSERT_EQUAL(return_value, E_OK);
     ASSERT_EQUAL(os_threads[1].state, THREAD_STATE_MIGRATING);
     ASSERT_EQUAL(os_threads[1].core_id, 1);
 
@@ -95,6 +90,6 @@ CTEST2(os_thread_migrate, rejected_migration_running_thread) {
 
     int return_value = os_thread_migrate(0, 1);
     ASSERT_EQUAL(return_value, E_INVALID);
-    ASSERT_EQUAL(os_threads[1].state, THREAD_STATE_RUNNING);
-    ASSERT_EQUAL(os_threads[1].core_id, 0);
+    ASSERT_EQUAL(os_threads[0].state, THREAD_STATE_RUNNING);
+    ASSERT_EQUAL(os_threads[0].core_id, 0);
 }

--- a/src/os/kernel/tests/os_thread_migrate.c
+++ b/src/os/kernel/tests/os_thread_migrate.c
@@ -17,6 +17,11 @@ extern int os_thread_migrate(uint8_t thread_id, int status);
 extern bool schedule_context_switch_called;
 extern unsigned cmrx_current_core;
 
+int os_thread_migrate(uint8_t, int)
+{
+    return 0;
+}
+
 CTEST_DATA(os_thread_migrate) {
 };
 
@@ -56,6 +61,7 @@ CTEST2(os_thread_migrate, clean_migration_stopped_thread) {
     cmrx_current_core = 0;
 
     int return_value = os_thread_migrate(1, 1);
+    ASSERT_EQUAL(return_value, E_INVALID);
     ASSERT_EQUAL(os_threads[1].state, THREAD_STATE_MIGRATING);
     ASSERT_EQUAL(os_threads[1].core_id, 1);
 

--- a/src/os/kernel/tests/os_txn.c
+++ b/src/os/kernel/tests/os_txn.c
@@ -1,0 +1,185 @@
+#include <cmrx/os/txn.h>
+#include <cmrx/defines.h>
+#include <ctest.h>
+
+/* Undisturbed read-only transaction will commit cleanly */
+CTEST(os_txn, txn_start_read_commit) 
+{
+    Txn_t id = os_txn_start();
+
+    int rv = os_txn_commit(id, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_OK);
+}
+
+/* Undisturbed read-write transaction will commit cleanly */
+CTEST(os_txn, txn_start_write_commit) 
+{
+    Txn_t id = os_txn_start();
+
+    int rv = os_txn_commit(id, TXN_READWRITE);
+    os_txn_done();
+
+    ASSERT_EQUAL(rv, E_OK);
+}
+
+/* Succeeding undistrubed transactions commit
+ * cleanly */
+CTEST(os_txn, txn_serialize_write)
+{
+    Txn_t id = os_txn_start();
+
+    int rv = os_txn_commit(id, TXN_READWRITE);
+    os_txn_done();
+
+    ASSERT_EQUAL(rv, E_OK);
+
+    id = os_txn_start();
+
+    rv = os_txn_commit(id, TXN_READWRITE);
+    os_txn_done();
+
+    ASSERT_EQUAL(rv, E_OK);
+}
+
+/* Succeeding undistrubed transactions commit
+ * cleanly */
+CTEST(os_txn, txn_serialize_read)
+{
+    Txn_t id = os_txn_start();
+
+    int rv = os_txn_commit(id, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_OK);
+
+    id = os_txn_start();
+
+    rv = os_txn_commit(id, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_OK);
+}
+
+/* Succeeding undistrubed transactions commit
+ * cleanly */
+CTEST(os_txn, txn_serialize_mixed)
+{
+    Txn_t id = os_txn_start();
+
+    int rv = os_txn_commit(id, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_OK);
+
+    id = os_txn_start();
+
+    rv = os_txn_commit(id, TXN_READWRITE);
+    os_txn_done();
+
+    ASSERT_EQUAL(rv, E_OK);
+
+    id = os_txn_start();
+
+    rv = os_txn_commit(id, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_OK);
+}
+
+/* Commiting a read-only transaction won't invalidate
+ * any on the fly read-only transaction. */
+CTEST(os_txn, txn_multi_read_commit_clean)
+{
+    Txn_t id_1 = os_txn_start();
+    Txn_t id_2 = os_txn_start();
+
+    int rv = os_txn_commit(id_2, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_OK);
+
+    rv = os_txn_commit(id_1, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_OK);
+}
+
+/* Commiting a read-only transaction won't invalidate
+ * any on the fly read-only transaction. */
+CTEST(os_txn, txn_read_interleaved_commit_clean)
+{
+    Txn_t id_1 = os_txn_start();
+    Txn_t id_2 = os_txn_start();
+
+    int rv = os_txn_commit(id_1, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_OK);
+
+    rv = os_txn_commit(id_2, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_OK);
+}
+
+/* Commiting a read-only transaction won't invalidate
+ * any on the fly read-write transaction. */
+CTEST(os_txn, txn_write_interrupt_read_commit_clean)
+{
+    Txn_t id_1 = os_txn_start();
+    Txn_t id_2 = os_txn_start();
+
+    int rv = os_txn_commit(id_2, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_OK);
+
+    rv = os_txn_commit(id_1, TXN_READWRITE);
+    os_txn_done();
+
+    ASSERT_EQUAL(rv, E_OK);
+}
+
+/* Commiting a read-write transaction will abort all
+ * on the fly read-only transaction. */
+CTEST(os_txn, txn_read_write_interleaved_abort)
+{
+    Txn_t id_1 = os_txn_start();
+    Txn_t id_2 = os_txn_start();
+
+    int rv = os_txn_commit(id_1, TXN_READWRITE);
+    os_txn_done();
+
+    ASSERT_EQUAL(rv, E_OK);
+
+    rv = os_txn_commit(id_2, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_INVALID);
+}
+
+/* Commiting a read-write transaction will abort
+ * all on the fly read-write transactions. */
+CTEST(os_txn, txn_multi_write_aborted)
+{
+    Txn_t id_1 = os_txn_start();
+    Txn_t id_2 = os_txn_start();
+
+    int rv = os_txn_commit(id_2, TXN_READWRITE);
+    os_txn_done();
+
+    ASSERT_EQUAL(rv, E_OK);
+
+    rv = os_txn_commit(id_1, TXN_READWRITE);
+
+    ASSERT_EQUAL(rv, E_INVALID);
+}
+
+/* Commiting a read-write transaction will abort all
+ * on the fly read-only transaction. */
+CTEST(os_txn, txn_read_nested_write_aborted)
+{
+    Txn_t id_1 = os_txn_start();
+    Txn_t id_2 = os_txn_start();
+
+    int rv = os_txn_commit(id_2, TXN_READWRITE);
+    os_txn_done();
+
+    ASSERT_EQUAL(rv, E_OK);
+
+    rv = os_txn_commit(id_1, TXN_READONLY);
+
+    ASSERT_EQUAL(rv, E_INVALID);
+
+}

--- a/src/os/kernel/tests/os_txn.c
+++ b/src/os/kernel/tests/os_txn.c
@@ -2,7 +2,7 @@
 #include <cmrx/defines.h>
 #include <arch/corelocal.h>
 #include <ctest.h>
-#include <stdbool.h>>
+#include <stdbool.h>
 
 extern callback_t cmrx_smp_wrong_lock_callback;
 
@@ -208,8 +208,10 @@ CTEST(os_txn, commit_neste_start_detected)
     int rv = os_txn_commit(id_1, TXN_READWRITE);
     
     ASSERT_EQUAL(test_lock_abort_called, false);
+    ASSERT_EQUAL(rv, E_OK);
 
     Txn_t id_2 = os_txn_start();
+    (void)id_2;
 
     ASSERT_EQUAL(test_lock_abort_called, true);
     

--- a/src/os/kernel/tests/smp_atomic_ops.c
+++ b/src/os/kernel/tests/smp_atomic_ops.c
@@ -108,6 +108,12 @@ CTEST2(smp_atomic, os_setitimer) {
 }
 
 CTEST2(smp_atomic, os_usleep) {
+    // Template steps:
+    // 1. before os_usleep is called
+    // 2. transaction is created in do_set_timed_event
+    // 3. transaction is commited in do_set_timed_event
+    // 4. transaction is created in sched_yield
+    // 5. transaction is commited in sched_yield
     static struct TimerEntry_t template[] = {{0, 0, 0xFF}, {0, 0, 0xFF}, {0, 10000, 4}, {0, 10000, 4}, {0, 10000, 4}};
 
     struct checker_t * checker = checker_create(&sleepers[0], template, sizeof(struct TimerEntry_t), ARR_SIZE(template), &cmrx_os_smp_locked);

--- a/src/os/kernel/tests/smp_atomic_ops.c
+++ b/src/os/kernel/tests/smp_atomic_ops.c
@@ -1,0 +1,48 @@
+#include "background_checker.h"
+
+#include <ctest.h>
+#include <stdint.h>
+#include <string.h>
+#include <cmrx/os/runtime.h>
+#include <arch/corelocal.h>
+
+extern struct OS_stack_t os_stacks;
+extern unsigned cmrx_os_smp_locked;
+
+struct barrier_t * current_barrier = NULL;
+
+void test_smp_locked_cb() {
+    barrier_wait(current_barrier);
+}
+
+CTEST_DATA(smp_atomic) {
+};
+
+CTEST_SETUP(smp_atomic) 
+{
+    (void) data;
+	memset(&os_stacks, 0, sizeof(os_stacks));
+    cmrx_smp_locked_callback = test_smp_locked_cb;
+}
+
+extern int os_stack_create();
+extern void os_stack_dispose(uint32_t stack_id);
+
+/** This test tests that when os_stack_create is called that:
+ * - kernel SMP lock is locked exactly once
+ * - before the lock is locked, the value of stack allocation bitmap is 0
+ * - after the lock is unlocked, the value of stack allocation bitmap is 1
+ */
+CTEST2(smp_atomic, os_stack_alloc) {
+    uint32_t template[2] = { 0, 1 };
+
+    struct barrier_t * barrier = barrier_create();
+    current_barrier = barrier;
+    struct checker_t * checker = checker_create(&os_stacks.allocations, template, sizeof(os_stacks.allocations), 2, &cmrx_os_smp_locked, barrier);
+
+    int rv = os_stack_create();
+
+    ASSERT_EQUAL(checker_finish(checker), 0);
+    ASSERT_EQUAL(cmrx_os_smp_locked, 0);
+    ASSERT_EQUAL(rv, 0);
+}

--- a/src/os/kernel/tests/smp_atomic_ops.c
+++ b/src/os/kernel/tests/smp_atomic_ops.c
@@ -47,7 +47,7 @@ CTEST2(smp_atomic, os_stack_alloc) {
 }
 
 CTEST2(smp_atomic, os_stack_dispose) {
-    uint32_t template[3] = { 1, 0, 1 };
+    uint32_t template[3] = { 0, 1, 0 };
 
     struct checker_t * checker = checker_create(&os_stacks.allocations, template, sizeof(os_stacks.allocations), 3, &cmrx_os_smp_locked, barrier);
 

--- a/src/os/kernel/timer.c
+++ b/src/os/kernel/timer.c
@@ -101,6 +101,7 @@ static int set_timed_event(unsigned microseconds, bool periodic)
                 return 0;
             } else {
                 // Transaction has been aborted, restart search
+                txn = os_txn_start();
                 q = -1;
                 continue;
             }
@@ -119,6 +120,7 @@ static int set_timed_event(unsigned microseconds, bool periodic)
 					if (do_set_timed_event(txn, q, microseconds, periodic) == 0) {
                         return 0;
                     } else {
+                        txn = os_txn_start();
                         q = -1;
                         continue;
                     }

--- a/src/os/kernel/txn.c
+++ b/src/os/kernel/txn.c
@@ -50,7 +50,6 @@ int os_txn_start_commit() {
 }
 
 void os_txn_done() {
-    printf("\nTransaction %d done!\n", os_txn_current_id);
     os_smp_unlock();
     os_core_unlock();
 

--- a/src/os/kernel/txn.c
+++ b/src/os/kernel/txn.c
@@ -1,0 +1,57 @@
+#include <arch/corelocal.h>
+#include <cmrx/os/txn.h>
+#include <cmrx/defines.h>
+#include <stdio.h>
+
+static Txn_t os_txn_current_id = 0;
+
+Txn_t os_txn_start() {
+    os_core_lock();
+    os_smp_lock();
+    Txn_t rv = os_txn_current_id;
+//    printf("Transaction started %u\n", rv);
+    os_smp_unlock();
+    os_core_unlock();
+
+    return rv;
+}
+
+int os_txn_commit(Txn_t transaction, enum TxnType type) {
+    os_core_lock();
+    os_smp_lock();
+    if (os_txn_current_id == transaction) {
+//        printf("Transaction committed %u\n", transaction);
+        if (type == TXN_READWRITE) {
+            os_txn_current_id++;
+            // critical section is entered by the calling code
+        } else {
+            // there is nothing to commit in read-only transaction so the critical
+            // section is left
+            os_smp_unlock();
+            os_core_unlock();
+        }
+        
+        return E_OK;
+    } 
+
+//    printf("Transaction aborted %u\n", transaction);
+    // transaction must be aborted as another transaction has already been commited
+    os_smp_unlock();
+    os_core_unlock();
+    return E_INVALID;
+}
+
+int os_txn_start_commit() {
+    os_core_lock();
+    os_smp_lock();
+    os_txn_current_id++;
+
+    return E_OK;
+}
+
+void os_txn_done() {
+    printf("\nTransaction %d done!\n", os_txn_current_id);
+    os_smp_unlock();
+    os_core_unlock();
+
+}

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -27,4 +27,4 @@ endif()
 
 message(STATUS "GDB: ${CMRX_GDB_PATH}")
 
-find_tests(${CMAKE_CURRENT_SOURCE_DIR})
+find_tests(${CMAKE_CURRENT_SOURCE_DIR} ${CMRX_PLATFORM_TEST_SRC})

--- a/testsuite/kill/init.c
+++ b/testsuite/kill/init.c
@@ -1,6 +1,7 @@
 #include <cmrx/ipc/thread.h>
 #include <cmrx/application.h>
 #include <debug.h>
+#include <utils.h>
 #include <cmrx/ipc/signal.h>
 
 int thread_main(void *)

--- a/testsuite/main.c
+++ b/testsuite/main.c
@@ -1,11 +1,16 @@
-#include <cmrx/os/sched.h>
+#include <cmrx/cmrx.h>
 #include <debug.h>
 #include <extra/systick.h>
+#include <conf/kernel.h>
 
 int main(void)
 {
     timing_provider_setup(1);
-	os_start();
+#ifdef CMRX_ARCH_SMP_SUPPORTED
+	os_start(0);
+#else
+    os_start();
+#endif
     TEST_FAIL();
     // This will never be called but it forces TEST_STEP to be 
     // linked into binary. This enables the generic GDB script to

--- a/testsuite/os_start/init.c
+++ b/testsuite/os_start/init.c
@@ -1,5 +1,6 @@
 #include <cmrx/application.h>
 #include <debug.h>
+#include <utils.h>
 
 int init_main(void * data)
 {

--- a/testsuite/process_data_access/init.c
+++ b/testsuite/process_data_access/init.c
@@ -1,5 +1,6 @@
 #include <cmrx/application.h>
 #include <debug.h>
+#include <utils.h>
 
 static int process_variable = 0;
 

--- a/testsuite/rpc_call/caller.c
+++ b/testsuite/rpc_call/caller.c
@@ -2,6 +2,7 @@
 #include <cmrx/ipc/thread.h>
 #include <cmrx/ipc/rpc.h>
 #include <debug.h>
+#include <utils.h>
 #include "service.h"
 
 int caller_high_prio(void * data)

--- a/testsuite/rpc_return/caller.c
+++ b/testsuite/rpc_return/caller.c
@@ -1,6 +1,7 @@
 #include <cmrx/application.h>
 #include <cmrx/ipc/rpc.h>
 #include <debug.h>
+#include <utils.h>
 #include "service.h"
 
 int caller_high_prio(void * data)

--- a/testsuite/rpc_shared_memory/caller.c
+++ b/testsuite/rpc_shared_memory/caller.c
@@ -3,6 +3,7 @@
 #include <cmrx/ipc/rpc.h>
 #include <cmrx/ipc/shmem.h>
 #include <debug.h>
+#include <utils.h>
 #include "service.h"
 
 char SHARED buffer[] = "Babedeadbabedead";

--- a/testsuite/sched_prio/init.c
+++ b/testsuite/sched_prio/init.c
@@ -1,5 +1,6 @@
 #include <cmrx/application.h>
 #include <debug.h>
+#include <utils.h>
 
 int init_high_prio(void * data)
 {

--- a/testsuite/sched_yield/init.c
+++ b/testsuite/sched_yield/init.c
@@ -1,6 +1,7 @@
 #include <cmrx/application.h>
 #include <cmrx/ipc/thread.h>
 #include <debug.h>
+#include <utils.h>
 
 int init_high_prio(void * data)
 {

--- a/testsuite/setpriority/init.c
+++ b/testsuite/setpriority/init.c
@@ -1,6 +1,7 @@
 #include <cmrx/application.h>
 #include <cmrx/ipc/thread.h>
 #include <debug.h>
+#include <utils.h>
 
 int new_thread_entry(void * data)
 {

--- a/testsuite/signal_kill/init.c
+++ b/testsuite/signal_kill/init.c
@@ -1,6 +1,7 @@
 #include <cmrx/ipc/thread.h>
 #include <cmrx/application.h>
 #include <debug.h>
+#include <utils.h>
 #include <cmrx/ipc/signal.h>
 
 void signal_handler(uint32_t signo)

--- a/testsuite/syscall_usleep/init.c
+++ b/testsuite/syscall_usleep/init.c
@@ -1,6 +1,7 @@
 #include <cmrx/application.h>
 #include <cmrx/ipc/timer.h>
 #include <debug.h>
+#include <utils.h>
 
 int init_high_prio(void * data)
 {

--- a/testsuite/thread_create_high_prio/init.c
+++ b/testsuite/thread_create_high_prio/init.c
@@ -1,6 +1,7 @@
 #include <cmrx/application.h>
 #include <cmrx/ipc/thread.h>
 #include <debug.h>
+#include <utils.h>
 
 int new_thread_entry(void * data)
 {

--- a/testsuite/thread_create_low_prio/init.c
+++ b/testsuite/thread_create_low_prio/init.c
@@ -1,6 +1,7 @@
 #include <cmrx/application.h>
 #include <cmrx/ipc/thread.h>
 #include <debug.h>
+#include <utils.h>
 
 int new_thread_entry(void * data)
 {

--- a/testsuite/thread_exit/init.c
+++ b/testsuite/thread_exit/init.c
@@ -1,6 +1,7 @@
 #include <cmrx/application.h>
 #include <cmrx/ipc/thread.h>
 #include <debug.h>
+#include <utils.h>
 
 int new_thread_entry(void * data)
 {

--- a/testsuite/thread_join/init.c
+++ b/testsuite/thread_join/init.c
@@ -1,6 +1,8 @@
+#include "cmrx/os/runtime.h"
 #include <cmrx/application.h>
 #include <cmrx/ipc/thread.h>
 #include <debug.h>
+#include <utils.h>
 
 int new_thread_entry(void * data)
 {

--- a/testsuite/utils.h
+++ b/testsuite/utils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef OS_THREAD_CREATE
+#undef OS_THREAD_CREATE
+#endif
+
+#define OS_THREAD_CREATE(application, entrypoint, data, priority) \
+_OS_THREAD_CREATE(application, entrypoint, data, priority, 0)
+


### PR DESCRIPTION
SMP support in kernel allows running CMRX kernel on more than one core simultaneously. All thread state-affecting calls should be executed in consistent manner (e.g. signals don't get lost). It is possible to migrate thread from one core to another.