### PR TITLE
Make stack size compile-time configurable

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,6 +1,10 @@
 option(CMRX_ARCH_SMP_SUPPORTED "Architecture supports SMP and project is using it" OFF)
 option(CMRX_OS_NUM_CORES "Amount of cores present in CPU package" INT:1)
 option(CMRX_UNIT_TESTS "Enable build of kernel unit tests" ON)
+set(OS_STACK_SIZE 1024 CACHE STRING "Stack allocated per thread in bytes")
+set(OS_THREADS 8 CACHE STRING "Amount of entries in the thread table")
+set(OS_PROCESSES 8 CACHE STRING "Amount of entries in the process table")
+set(OS_STACKS 8 CACHE STRING "Amount of stacks allocated")
 
 # List of CMake options that are transferred into nested build
 set(CMRX_ALL_OPTIONS CMRX_ARCH_SMP_SUPPORTED CMRX_OS_NUM_CORES)

--- a/conf/kernel.h
+++ b/conf/kernel.h
@@ -1,7 +1,8 @@
 /** @defgroup os_config Kernel runtime configuration
  * Compile-time configuration of kernel runtime parameters.
- * Some kernel properties can be configured statically at compile-time. For some of them
- * it is the only way to configure them at all.
+ * Do not modify this file directly. Use CMake options in your top-level CMakeLists.txt
+ * to alter generation of this file. Any changes done to this file may be overwritten
+ * by the build system!
  * @{
  */
 #pragma once
@@ -22,16 +23,19 @@
 #define OS_TASK_MPU_REGIONS		5
 
 /** How big stack is? In bytes */
-#define OS_STACK_SIZE			1024
+#define OS_STACK_SIZE  @OS_STACK_SIZE@
+#ifndef OS_STACK_SIZE
+#   error "Stack size not defined! Fix your CMakeLists.txt!"
+#endif
 
 /** How many threads can exist */
-#define OS_THREADS				8
+#define OS_THREADS				@OS_THREADS@
 
 /** How many stacks can be allocated */
-#define OS_STACKS				8
+#define OS_STACKS				@OS_STACKS@
 
 /** How many processes can be allocated */
-#define OS_PROCESSES 			8
+#define OS_PROCESSES 			@OS_PROCESSES@
 
 /** How many sleeping threads can exist */
 #define SLEEPERS_MAX			(2 * OS_THREADS)
@@ -40,5 +44,7 @@
 #ifdef CMRX_ARCH_SMP_SUPPORTED
 #    define OS_NUM_CORES    @CMRX_OS_NUM_CORES@
 #endif
+
+#define OS_NOTIFICATION_BUFFER_SIZE     16
 
 /** @} */

--- a/src/os/kernel/sched.c
+++ b/src/os/kernel/sched.c
@@ -39,7 +39,7 @@ struct OS_core_state_t core[OS_NUM_CORES];
 #define STACK_INVALID       0xFFFFFFFFU
 
 /// @cond IGNORE
-__attribute__((aligned(1024))) 
+__attribute__((aligned(OS_STACK_SIZE)))
 /// @endcond
 /** Thread stacks */
 struct OS_stack_t os_stacks;


### PR DESCRIPTION
Up until now stack size has been fixed at 1kB per thread which may not be enough for certain tasks. Make stack size configurable via CMakeLists. Other kernel configuration options also made configurable via CMakeLists.