### PR TITLE
Add kernel tracing infrastructure

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,10 +1,19 @@
 option(CMRX_ARCH_SMP_SUPPORTED "Architecture supports SMP and project is using it" OFF)
 option(CMRX_OS_NUM_CORES "Amount of cores present in CPU package" INT:1)
 option(CMRX_UNIT_TESTS "Enable build of kernel unit tests" ON)
+option(CMRX_KERNEL_TRACING "Enable tracing of kernel events" OFF)
 set(OS_STACK_SIZE 1024 CACHE STRING "Stack allocated per thread in bytes")
 set(OS_THREADS 8 CACHE STRING "Amount of entries in the thread table")
 set(OS_PROCESSES 8 CACHE STRING "Amount of entries in the process table")
 set(OS_STACKS 8 CACHE STRING "Amount of stacks allocated")
 
 # List of CMake options that are transferred into nested build
-set(CMRX_ALL_OPTIONS CMRX_ARCH_SMP_SUPPORTED CMRX_OS_NUM_CORES)
+set(CMRX_ALL_OPTIONS
+    CMRX_ARCH_SMP_SUPPORTED
+    CMRX_OS_NUM_CORES
+    CMRX_KERNEL_TRACING
+    OS_STACK_SIZE
+    OS_THREADS
+    OS_PROCESSES
+    OS_STACKS
+    )

--- a/conf/kernel.h
+++ b/conf/kernel.h
@@ -47,4 +47,7 @@
 
 #define OS_NOTIFICATION_BUFFER_SIZE     16
 
+/** Enable / disable kernel tracing */
+#cmakedefine CMRX_KERNEL_TRACING
+
 /** @} */

--- a/include/cmrx/sys/trace.h
+++ b/include/cmrx/sys/trace.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <conf/kernel.h>
+
+/** @defgroup os_tracing Tracing Kernel Events
+ * @ingroup os
+ * Facilities to trace progress of kernel execution
+ *
+ * Sometimes the current state of system as inspected by the debugger
+ * is not enough to fully understand what happens and why it happens.
+ * For these rough days the kernel tracing infrastructure offers facility
+ * to track certain events as they happened.
+ *
+ * If tracing infrastructure is enabled by CMake option then tracing
+ * infrastructure support is built into kernel. This infrastructure is called
+ * from certain places. As of now tracing is all or nothing. Once tracing
+ * is enabled all trace events currently present in the code are recorded
+ * if they happen.
+ *
+ * Trace buffer is a circular buffer that overwrites oldest recorded entries
+ * if new events are traced and the buffer is not large enough to store them.
+ *
+ * @section os_tracing_enable Enabling tracing
+ *
+ * In order for tracing to be active the developer needs to turn on CMake
+ * option named `CMRX_KERNEL_TRACING`. Then it is necessary to call function
+ * @ref trace_init() which will tell the tracing infrastructure where the tracing
+ * buffer can be stored.
+ *
+ * Tracing buffer is not allocated normally, rather it is developer's task to find
+ * a suitable space outside of normally used memory where it can be placed.
+ *
+ * This buffer will be "formatted" during the initialization and subsequent calls
+ * to @ref trace_event() will record events there.
+ *
+ * If buffer is not initialized then calls to @ref trace_event() do nothing.
+ *
+ * @section os_tracing_retrieving Retrieving trace data
+ *
+ * Trace data is stored in RAM. In order to process them one has to dump them to
+ * the computer. This can be done in many ways. One possible way is to use the
+ * provided GDB script. This script is available in CMRX kernel repository in
+ * gdb/trace_log.gdb file. It provides dump_trace command. This command will dump
+ * trace in human readable form into file `trace.log` into current working directory.
+ *
+ * @ingroup os_tracing
+ * @{
+ */
+
+enum TraceEventID {
+    EVENT_NONE = 0,
+    EVENT_CPU_BOOT,
+    EVENT_THREAD_SWITCH,
+    EVENT_SYSCALL,
+    EVENT_NOTIFY_WAIT_INIT,
+    EVENT_NOTIFY_WAITING,
+    EVENT_NOTIFY_PENDING,
+    EVENT_WAIT_PENDING,
+    EVENT_WAIT_SUSPEND,
+    EVENT_ISR_HANDLER,
+    EVENT_KERNEL_TICK
+};
+
+/// @cond IGNORE
+#ifndef CMRX_KERNEL_TRACING
+#   define trace_init(start_addr, end_addr)
+#   define trace_event(event, arg)
+#else
+/// @endcond
+/** Initialize trace buffer.
+ * Trace buffer is usually put outside of the allocated RAM so
+ * it can occupy otherwise unused and unallocated RAM space.
+ * @param start_addr start address of the trace buffer
+ * @param end_addr last usable address by the trace buffer
+ * @returns true if trace buffer has been initialized. False is returned
+ * if trace buffer is already initialized.
+ */
+bool trace_init(void * start_addr, void * end_addr);
+
+/** Trace event.
+ * This will trace event into trace buffer.
+ * @param event The event that happened
+ * @param arg optional argument to the event, event-specific
+ * @note If trace buffer was not initialized then this call does nothing.
+ * Please mind that even then the call happens and consumes CPU cycles.
+ */
+void trace_event(enum TraceEventID event, uint32_t arg);
+#endif
+
+/// @}

--- a/src/extra/systick.c
+++ b/src/extra/systick.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <cmrx/clock.h>
 #include CMSIS_device_header
+#include <cmrx/sys/trace.h>
 
 static uint32_t systick_us = 0;
 
@@ -31,6 +32,7 @@ void timing_provider_setup(int interval_ms)
 
 __attribute__((interrupt)) void SysTick_Handler()
 {
+    trace_event(EVENT_KERNEL_TICK, systick_us);
     os_sched_timing_callback(systick_us);
 }
 

--- a/src/os/arch/arm/pendsv.c
+++ b/src/os/arch/arm/pendsv.c
@@ -20,6 +20,8 @@
 #   include <arch/mpu_priv.h>
 #endif
 
+#include <kernel/trace.h>
+
 void os_request_context_switch()
 {
 	SCB_ICSR |= SCB_ICSR_PENDSVSET;
@@ -76,6 +78,9 @@ __attribute__((naked)) void PendSV_Handler(void)
 		os_deliver_signal(cpu_context.new_task, cpu_context.new_task->signals);
 		cpu_context.new_task->signals = 0;
 	}
+
+	trace_event(EVENT_THREAD_SWITCH, cpu_context.new_task - os_threads);
+
 	if (os_threads[cpu_state->thread_current].state == THREAD_STATE_RUNNING)
 	{
 		// only mark leaving thread as ready, if it was runnig before

--- a/src/os/arch/arm/syscall.c
+++ b/src/os/arch/arm/syscall.c
@@ -14,6 +14,8 @@
 #include <arch/cortex.h>
 #include <arch/nvic.h>
 
+#include <kernel/trace.h>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 
@@ -50,6 +52,7 @@ __attribute__((interrupt)) void SVC_Handler(void)
 	ExceptionFrame * frame = (ExceptionFrame *) psp;
 	uint16_t * lra = (uint16_t *) frame->pc;
 	uint8_t syscall_id = *(lra - 1);
+	trace_event(EVENT_SYSCALL, syscall_id);
     uint32_t rv = os_system_call(frame->r0123[0], frame->r0123[1], frame->r0123[2], frame->r0123[3], syscall_id);
     *(psp) = rv;
     return; /*asm volatile("BX lr");*/

--- a/src/os/kernel/CMakeLists.txt
+++ b/src/os/kernel/CMakeLists.txt
@@ -13,9 +13,14 @@ set(os_SRCS
     sched.c 
     signal.c 
     syscall.c 
-    timer.c 
+    timer.c
     txn.c
     rpc.c)
+
+# Add tracing source file if tracing is enabled
+if (CMRX_KERNEL_TRACING)
+    list(APPEND os_SRCS trace.c)
+endif()
 
 add_library(os STATIC EXCLUDE_FROM_ALL ${os_SRCS})
 get_property(CMRX_ROOT_DIR GLOBAL PROPERTY CMRX_ROOT_DIR)

--- a/src/os/kernel/sched.c
+++ b/src/os/kernel/sched.c
@@ -20,6 +20,7 @@
 #include <cmrx/sys/syscalls.h>
 #include <cmrx/clock.h>
 #include <string.h>
+#include <kernel/trace.h>
 
 #define STACK_ALIGN 
 
@@ -528,6 +529,9 @@ __attribute__((noreturn)) void _os_start(uint8_t start_core)
 {
     volatile Thread_t created_threads[8];
     volatile unsigned cursor = 0;
+
+    trace_event(EVENT_CPU_BOOT, start_core);
+
     for (int q = 0; q < 8; ++q) {
         created_threads[q] = 0xFF;
     }
@@ -574,6 +578,8 @@ __attribute__((noreturn)) void _os_start(uint8_t start_core)
 
 	if (os_get_next_thread(0xFF, &startup_thread))
 	{
+        trace_event(EVENT_THREAD_SWITCH, startup_thread);
+
 		core[start_core].thread_current = startup_thread;
 		Process_t startup_process = os_threads[startup_thread].process_id;
 		os_threads[startup_thread].state = THREAD_STATE_RUNNING;

--- a/src/os/kernel/trace.c
+++ b/src/os/kernel/trace.c
@@ -1,0 +1,45 @@
+#include "trace.h"
+#include <cmrx/defines.h>
+
+static struct TraceBuffer * event_trace_buffer = NULL;
+
+#define TRACE_BUFFER_MAGIC  0xFACEFEED
+
+bool trace_init(void * start_addr, void * end_addr)
+{
+    // Trace event_trace_bufferfer can only be initialized once
+    if (event_trace_buffer != NULL)
+    {
+        return false;
+    }
+
+    event_trace_buffer = start_addr;
+    event_trace_buffer->magic = TRACE_BUFFER_MAGIC;
+    event_trace_buffer->most_recent_event = ~0;
+    event_trace_buffer->last_possible_event = ((struct TraceEvent *) end_addr) - &event_trace_buffer->events[0];
+    event_trace_buffer->wrapped = 0;
+
+    return true;
+}
+
+void trace_event(enum TraceEventID event, uint32_t arg)
+{
+    if (event_trace_buffer == NULL)
+    {
+        return;
+    }
+    if (event_trace_buffer->magic != TRACE_BUFFER_MAGIC)
+    {
+        return;
+    }
+    event_trace_buffer->most_recent_event++;
+    if (event_trace_buffer->most_recent_event > event_trace_buffer->last_possible_event)
+    {
+        event_trace_buffer->most_recent_event = 0;
+        event_trace_buffer->wrapped++;
+    }
+    int id = event_trace_buffer->most_recent_event;
+    event_trace_buffer->events[id].event_id = event;
+    event_trace_buffer->events[id].event_arg = arg;
+}
+

--- a/src/os/kernel/trace.h
+++ b/src/os/kernel/trace.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cmrx/sys/trace.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/** Kernel event tracing infrastructure */
+
+struct __attribute__((packed)) TraceEvent {
+    uint32_t event_id;
+    uint32_t event_arg;
+};
+
+struct __attribute__((packed)) TraceBuffer {
+    uint32_t magic;
+    uint32_t last_possible_event;
+    uint32_t most_recent_event;
+    uint32_t wrapped;
+    struct TraceEvent events[8192];
+};


### PR DESCRIPTION
Kernel tracing infrastructure allows developers to use otherwise unallocated RAM space for kernel event log. This circular log is filled with events recorded during the execution of the kernel. The log can then be downloaded into computer and visualized.