### PR TITLE
Fix scheduler corruptions

### DIFF
--- a/src/os/arch/arm/cmsis/arch/scb.h
+++ b/src/os/arch/arm/cmsis/arch/scb.h
@@ -10,14 +10,16 @@
 
 #   define SCB_CFSR (SCB->CFSR)
 
-#   define SCB_ICSR (SCB->ICSR)
 
-#   define SCB_ICSR_PENDSVSET (SCB_ICSR_PENDSVSET_Msk)
 #   define SCB_CFSR_IACCVIOL (SCB_CFSR_IACCVIOL_Msk)
 #   define SCB_CFSR_DACCVIOL (SCB_CFSR_DACCVIOL_Msk)
 #   define SCB_CFSR_MMARVALID (SCB_CFSR_MMARVALID_Msk)
 
 #endif
+
+#define SCB_ICSR (SCB->ICSR)
+#define SCB_ICSR_PENDSVSET (SCB_ICSR_PENDSVSET_Msk)
+#define SCB_ICSR_PENDSVCLR (SCB_ICSR_PENDSVCLR_Msk)
 
 
 #define cortex_disable_interrupts __disable_irq

--- a/src/os/arch/arm/sanitize.c
+++ b/src/os/arch/arm/sanitize.c
@@ -7,7 +7,13 @@ extern struct OS_stack_t os_stacks;
 void sanitize_psp(uint32_t * psp)
 {
     (void) psp;
-//	uint8_t stack_current = os_get_current_stack();
-//	ASSERT(&os_stacks.stacks[stack_current][0] <= psp && psp <= &os_stacks.stacks[stack_current][OS_STACK_DWORD]);
+	uint8_t stack_current = os_get_current_stack();
+	ASSERT(&os_stacks.stacks[stack_current][0] <= psp && psp <= &os_stacks.stacks[stack_current][OS_STACK_DWORD]);
+}
 
+void sanitize_psp_for_thread(uint32_t * psp, Thread_t thread_id)
+{
+    (void) psp;
+    struct OS_thread_t * thread = os_thread_get(thread_id);
+    ASSERT(&os_stacks.stacks[thread->stack_id][0] <= psp && psp <= &os_stacks.stacks[thread->stack_id][OS_STACK_DWORD]);
 }

--- a/src/os/arch/testing/pendsv.c
+++ b/src/os/arch/testing/pendsv.c
@@ -3,28 +3,46 @@
 #include <stdbool.h>
 #include <kernel/runtime.h>
 #include <arch/corelocal.h>
-
+#include <kernel/arch/context.h>
 #include <ctest.h>
 
 bool schedule_context_switch_called = false;
+// If set to false, then schedule_context_switch won't perform the thread switch
+bool schedule_context_switch_perform_switch = true;
+void (*schedule_context_switch_callback)() = NULL;
 
 extern struct OS_core_state_t core[OS_NUM_CORES];
 
-void os_request_context_switch()
+void os_request_context_switch(bool activate)
 {
-    Thread_t thread_current = core[0].thread_current;
-    Thread_t thread_next = core[0].thread_next;
 
-    // This was here. Yet, there are states where this rule doesn't hold
-    // like if you call wait_for_object()
-    // ASSERT_EQUAL(os_threads[thread_next].state, THREAD_STATE_READY);
-    core[coreid()].thread_current = core[coreid()].thread_next;
-    if (os_threads[thread_current].state == THREAD_STATE_RUNNING)
+    if (schedule_context_switch_perform_switch)
     {
-        os_threads[thread_current].state = THREAD_STATE_READY;
+        if (activate)
+        {
+            Thread_t thread_current = core[0].thread_current;
+            Thread_t thread_next = core[0].thread_next;
+
+            // This was here. Yet, there are states where this rule doesn't hold
+            // like if you call wait_for_object()
+            // ASSERT_EQUAL(os_threads[thread_next].state, THREAD_STATE_READY);
+            core[coreid()].thread_current = core[coreid()].thread_next;
+            if (os_threads[thread_current].state == THREAD_STATE_RUNNING)
+            {
+                os_threads[thread_current].state = THREAD_STATE_READY;
+            }
+            os_threads[thread_next].state = THREAD_STATE_RUNNING;
+
+            // Currently existing tests expect this to be called only
+            // for activate = true cases.
+            schedule_context_switch_called = true;
+        }
     }
-    os_threads[thread_next].state = THREAD_STATE_RUNNING;
-    schedule_context_switch_called = true;
+
+
+    if (schedule_context_switch_callback != NULL)
+    {
+        schedule_context_switch_callback();
+    }
 //    ctxt_switch_pending = false;
 }
-

--- a/src/os/kernel/arch/context.h
+++ b/src/os/kernel/arch/context.h
@@ -13,4 +13,4 @@
  * as kernel finishes its work and is ready to return the
  * CPU back to the userspace code.
  */
-void os_request_context_switch();
+void os_request_context_switch(bool activate);

--- a/src/os/kernel/context.c
+++ b/src/os/kernel/context.c
@@ -69,7 +69,7 @@ bool schedule_context_switch(uint32_t current_task, uint32_t next_task)
 
     cpu_context.new_stack = os_stacks.stacks[cpu_context.new_task->stack_id];
 
-    os_request_context_switch();
+    os_request_context_switch(true);
 
 	return true;
 }

--- a/src/os/kernel/sanitize.h
+++ b/src/os/kernel/sanitize.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "runtime.h"
 
 /** Checks that PSP is within sane limits.
  *
@@ -10,3 +11,12 @@
  */
 void sanitize_psp(uint32_t * psp);
 
+/** Checks that PSP is within limits for given thread.
+ *
+ * This function does the same as @ref sanitize_psp() yet with
+ * explicitly set thread in whose context the PSP should be
+ * checked.
+ * @param PSP value of PSP register (actual, or intended)
+ * @param thread_id ID of thread PSP should be checked for validity
+ */
+void sanitize_psp_for_thread(uint32_t * psp, Thread_t thread_id);

--- a/src/os/kernel/sched.c
+++ b/src/os/kernel/sched.c
@@ -14,6 +14,7 @@
 #include <cmrx/assert.h>
 #include "arch/static.h"
 #include "arch/sched.h"
+#include "arch/context.h"
 #include "context.h"
 #include "arch/mpu.h"
 #include "timer.h"
@@ -123,6 +124,11 @@ int os_sched_yield(void)
             os_txn_done();
         }
  	}
+ 	else
+    {
+        os_request_context_switch(false);
+    }
+
 	return 0;
 }
 


### PR DESCRIPTION
1.  Fix scheduler corruption due to nested PendSV schedule
    
    There is a brief moment during which PendSV handler executes when
    interrupts are not disabled yet. As the PendSV is the lowest priority
    handler in the system, it may happen that it gets preempted by some
    other interrupt handler.
    
    This interrupt handler can issue isr_notify_object() or isr_kill()
    effectively causing sched_yield() being executed. If that happens,
    thread switch is planned by requesting PendSV to be called.
    
    While we already are executing PendSV handler, this causes PendSV being
    scheduled twice. This is usually not what you want.
    
    The fix here clears PendSV request still existing just before PendSV is
    going to return. These are spurious requests made in between PendSV
    handler being scheduled by CPU and disabling interrupts. They shall be
    served by now.

2.  Proper PSP sanitization checks, cancel PendSV if not needed anymore
    
    Reactivated PSP sanitization checks.
    
    Added PSP sanitization check in context of some specific thread.
    
    Context switch now can be disabled if not needed anymore. This happens
    e.g. in case that thread was suspended via syscall and then resumed via
    ISR handler before it managed to be swapped by PendSV. The call to
    PendSV can be cancelled entirely to save CPU cycles.

3.  Set correct thread state when notifying thread still running
    
    When thread is suspended due to waiting for object but ISR manages to
    come before PendSV executes thread switch and the ISR preempting PendSV
    performs notification of that very same object, then the thread is given
    incorrect state READY instead of RUNNING.
    
    This does not play well with short-circuited unnecessary thread
    switches, thus notification will check if thread is still the one
    scheduled on the current core and will assign it RUNNING state instead.

4. Update tests