### PR TITLE
Fix mutex unlock code, drop hand-written assembly

### DIFF
--- a/include/cmrx/ipc/mutex.h
+++ b/include/cmrx/ipc/mutex.h
@@ -23,6 +23,9 @@
  */
 #define FUTEX_STATIC_INIT		{ 0xFF, 0, 0 }
 
+#define FUTEX_SUCCESS					0
+#define FUTEX_FAILURE					1
+
 /** Futex structure.
  * This is fast userspace mutex, which avoids calling kernel.
  * It provides basic functionality for locking, unlocking and


### PR DESCRIPTION
Mutex unlock code ignored the fact that STREX may fail and did not perform mutex unlocking in loop. Instead, upon first failure it simply reported that mutex unlocking failed.

Now the mutex unlocking performs loop until the lock is unlocked.

Unlike locking, which can fail simply because mutex is held by someone else, STREX performed during unlocking should normally fail only due to how load/store-exclusive are designed. Thus another round of unlocking is tried immediately without yielding the CPU.

Removed hand-written assembly implementation of futex locking/unlocking. Replaced by C code using instrinsics for STREX and LDREX.