### PR TITLE
reorder futex_t entries for better optimization

### DIFF
--- a/include/cmrx/ipc/mutex.h
+++ b/include/cmrx/ipc/mutex.h
@@ -32,9 +32,9 @@
  * non-blocking lock. It can be single-issue, or recursive.
  */
 typedef struct {
+	uint8_t state;
 	uint8_t owner;
 	uint8_t flags;
-	uint8_t state;	
 } futex_t;
 
 /* Mutex structure.


### PR DESCRIPTION
`ldrex/strex` supports only one addressing mode - register.
Thus, if the state is not first member, compiler have to emit extra instruction to materialize address of `futex->state` in a register, which in turn increases register pressure and lead to less efficient code generated for `__futex_*` primitives.