### PR TITLE
__futex_fast_unlock: avoid redundant truncations to uint8_t

### DIFF
--- a/src/lib/arch/arm/mutex.c
+++ b/src/lib/arch/arm/mutex.c
@@ -53,7 +53,7 @@ int __futex_fast_lock(futex_t * futex, uint8_t thread_id, unsigned max_depth)
  */
 int __futex_fast_unlock(futex_t * futex, uint8_t thread_id)
 {
-	uint8_t state = __LDREXB(&futex->state);
+	unsigned state = __LDREXB(&futex->state);
 	int success = FUTEX_FAILURE;
 	ASSERT(state > 0);
 	if (state > 0)


### PR DESCRIPTION
At the moment `state` declared as `uint8_t` which forces compiler to truncate it explicitly after load or decrement operations. Truncation is unnecessary because strexb does implicit truncation.