### PR TITLE
Integrate clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: linuxkernel-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set_property(GLOBAL PROPERTY CMRX_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
 include(cmake/options.cmake)
 include(cmake/unit_test_build.cmake)
+include(cmake/clang-tidy.cmake)
 
 include_directories(include)
 include_directories(${CMAKE_BINARY_DIR})
@@ -71,3 +72,5 @@ endif()
 if (BUILD_TESTING)
     add_subdirectory(testing)
 endif()
+
+apply_clang_tidy(os)

--- a/cmake/CMRX.cmake
+++ b/cmake/CMRX.cmake
@@ -10,6 +10,8 @@ option(SW_TESTING_BUILD "Enabled hosted build. This can be used to build hosted 
 option(CMRX_SKIP_LINKER_FILE_USE "Skips automatic use of generated linker file by targets. Developer becomes responsible for the use of correct linker file" FALSE)
 option(CMRX_STDLIB_USE_CMSIS_CORE "Forces CMRX standard library to link against cmsis_core library. This is needed with some HALs to successfully link the project" FALSE)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 if (SW_TESTING_BUILD)
     include(${CMAKE_CURRENT_LIST_DIR}/arch/testing/CMRX.cmake)
     # Override arch name to "testing"

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -1,0 +1,40 @@
+find_program(CLANGTIDY_EXECUTABLE clang-tidy)
+
+if (CMRX_CLANG_TIDY AND "${CLANGTIDY_EXECUTABLE}" STREQUAL "CLANGTIDY_EXECUTABLE-NOTFOUND")
+    message(STATUS "Clang-tidy not found! Linting disabled!")
+endif()
+
+function(apply_clang_tidy TARGET)
+    if (NOT CMRX_CLANG_TIDY OR "${CLANGTIDY_EXECUTABLE}" STREQUAL "CLANGTIDY_EXECUTABLE-NOTFOUND")
+        return()
+    endif()
+
+    if (NOT TARGET ${TARGET})
+        message(FATAL_ERROR "apply_clang_tidy: ${TARGET} is not a valid target name!")
+    endif()
+
+    if (NOT TARGET clang-tidy)
+        add_custom_target(clang-tidy)
+    endif()
+
+    get_property(CMRX_ROOT_DIR GLOBAL PROPERTY CMRX_ROOT_DIR)
+
+    if ("${CMRX_ROOT_DIR}" STREQUAL "")
+        message(FATAL_ERROR "apply_clang_tidy: CMRX root dir property not set!")
+    endif()
+
+    get_target_property(TARGET_SOURCE_DIR ${TARGET} SOURCE_DIR)
+
+    get_target_property(TARGET_SOURCES ${TARGET} SOURCES)
+
+    add_custom_target(tidy-${TARGET}
+        COMMAND ${CLANGTIDY_EXECUTABLE}
+        -config-file=${CMRX_ROOT_DIR}/.clang-tidy
+        -p ${CMAKE_BINARY_DIR}
+        ${TARGET_SOURCES}
+        WORKING_DIRECTORY ${TARGET_SOURCE_DIR}
+        COMMENT "Linting ${TARGET}..."
+    )
+
+    add_dependencies(clang-tidy tidy-${TARGET})
+endfunction()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -2,6 +2,7 @@ option(CMRX_ARCH_SMP_SUPPORTED "Architecture supports SMP and project is using i
 option(CMRX_OS_NUM_CORES "Amount of cores present in CPU package" INT:1)
 option(CMRX_UNIT_TESTS "Enable build of kernel unit tests" ON)
 option(CMRX_KERNEL_TRACING "Enable tracing of kernel events" OFF)
+option(CMRX_CLANG_TIDY "Enable linting using Clang-tidy" ON)
 set(OS_STACK_SIZE 1024 CACHE STRING "Stack allocated per thread in bytes")
 set(OS_THREADS 8 CACHE STRING "Amount of entries in the thread table")
 set(OS_PROCESSES 8 CACHE STRING "Amount of entries in the process table")


### PR DESCRIPTION
This adds `apply_clang_tidy()` CMake command which allows seamless application of clang-tidy to any target. This relies on compile-commands.json being available in the root directory, so this option is turned on in the main CMakeLists.txt of the CMRX.

Clang-tidy is enabled by default if clang-tidy executable is found. It can be disabled by setting CMRX_CLANG_TIDY option to false.

Clang-tidy can be invoked by running the `clang-tidy` target. This is not done automatically during the build for two reasons: 1) clang-tidy is not particularly fast if many checks are enabled 2) currently it reports some weird errors (such as missing system
   headers)