### PR TITLE
PendSV_Handler fix violating ABI stack rules

### DIFF
--- a/src/os/arch/arm/cortex.c
+++ b/src/os/arch/arm/cortex.c
@@ -92,7 +92,7 @@ __attribute__((naked)) void PendSV_Handler(void)
 	/* Do NOT put anything here. You will clobber context being stored! */
 	asm volatile(
 			".syntax unified\n\t"
-			"push {lr}\n\t"
+			"push {r3, lr}\n\t"
 	);
 	cortex_disable_interrupts();
 	/* Do NOT put anything here. You will clobber context being stored! */
@@ -150,7 +150,7 @@ __attribute__((naked)) void PendSV_Handler(void)
 	/* Clear any potential stale pending service requests */
 	cortex_enable_interrupts();
 	asm volatile(
-			"pop {pc}"
+			"pop {r3, pc}"
 	);
 }
 


### PR DESCRIPTION
[AAPCS32](https://github.com/ARM-software/abi-aa/releases) states that stack pointer must be doubleword aligned whether a function calls another function.

Visible effect of that isn't specified explicitly but might affect various debugging facilities such as stack unwinder, core dump analysis, etc.

Let's store/restore something dummy in addition to return address to achieve required alignment.