### PR TITLE
save/load_context: avoid redundant activities

### DIFF
--- a/src/os/arch/arm/cmsis/arch/cortex.h
+++ b/src/os/arch/arm/cmsis/arch/cortex.h
@@ -90,7 +90,7 @@ ALWAYS_INLINE void * save_context()
 			"SUBS %0, #16\n\t"
 			: "=r" (scratch)
 			:
-			: "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11"
+			: 
 	);
 
 	return scratch;
@@ -112,7 +112,7 @@ ALWAYS_INLINE void load_context(uint32_t * sp)
 			"MSR PSP, %0\n\t"
 			:
 			: [scratch] "r" (sp)
-			: "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11"
+			: 
 	);
 }
 


### PR DESCRIPTION
There's no need to specify r4-r11 as clobbers.
Actually clobbering forces compiler to wrap these asm routines into push {r4-r11} ... pop {r4-r11} which results in 3x data to be loaded from/stored into memory.

NB: I didn't test the change actually.