### PR TITLE
Kernel: fix some clang-tidy warnings

### DIFF
--- a/src/os/kernel/notify.c
+++ b/src/os/kernel/notify.c
@@ -18,11 +18,10 @@ void os_notify_init()
 
 int os_initialize_waitable_object(const void* object)
 {
-    Txn_t txn_id = 0;
+    Txn_t txn_id = os_txn_start();
     Thread_t thread_id = 0;
     bool awaken = false;
     do {
-        txn_id = os_txn_start();
         if (os_threads[thread_id].state == THREAD_STATE_WAITING
             &&  os_threads[thread_id].wait_object == object)
         {
@@ -39,11 +38,10 @@ int os_initialize_waitable_object(const void* object)
 
                 notified_thread->wait_object = NULL;
                 os_txn_done();
-            } else {
-                txn_id = os_txn_start();
-                continue;
             }
 
+            // Success or not, new transaction has to be created
+            // as the old one has been already used
             txn_id = os_txn_start();
         }
         thread_id++;

--- a/src/os/kernel/txn.c
+++ b/src/os/kernel/txn.c
@@ -1,7 +1,6 @@
 #include <arch/corelocal.h>
 #include "txn.h"
 #include <cmrx/defines.h>
-#include <stdio.h>
 
 static Txn_t os_txn_current_id = 0;
 


### PR DESCRIPTION
Notification engine: clang-tidy pointed out that some transaction initializations are never used. It turns out that the whole code of os_initialize_writable_object() is ineffective in terms of creating too many transactions.

This function is not extremely performance-critical as of now, but getting rid of unnecessary transaction creation helps.

Also, remove unused header include in transaction code.