### PR TITLE
Fix: Checkapp.sh does not decode application name completely #59

### DIFF
--- a/ld/checkapp.sh
+++ b/ld/checkapp.sh
@@ -10,7 +10,7 @@ if [ ! -e $1 ]; then
     exit 1
 fi
 
-SYMS=`objdump -j.applications -t $1 | grep $2 | wc -l`
+SYMS=`objdump -j.applications -t $1 | grep -E "\<$2\>" | wc -l`
 
 if [ "${SYMS}" -eq "1" ]; then
     exit 0


### PR DESCRIPTION
I added a regex to match the start and end of the word so that inputs with prefixes/suffixes are handled correctly