### PR TITLE
Fix: Queue implementation concurrency data hazard

### DIFF
--- a/src/extra/queue_server/queue.c
+++ b/src/extra/queue_server/queue.c
@@ -54,11 +54,13 @@ bool queue_receive(struct Queue * queue, void * data)
         cursor = (cursor + 1) % size_limit;
     }
 
-    queue->read_cursor = cursor;
-    if (queue->read_cursor == queue->write_cursor)
+    // Update `empty` flag before updating cursor position
+    // otherwise we get a data hazard.
+    if (cursor == queue->write_cursor)
     {
         queue->empty = true;
     }
+    queue->read_cursor = cursor;
 
     return true;
 }


### PR DESCRIPTION
When the last item is read from the queue, then the status of the queue structure will briefly signalize that the queue is full instead of being empty. This is due to the fact that queue is inherently implemented as a lock-free structure.

Put empty flag update in front of the cursor update so this data hazard won't be ever visible from outside.