### PR TITLE
Feature/timer flexibility refactor

### DIFF
--- a/src/os/kernel/tests/os_sched_timing_callback.c
+++ b/src/os/kernel/tests/os_sched_timing_callback.c
@@ -6,12 +6,6 @@
 #include <string.h>
 #include <arch/corelocal.h>
 
-struct TimerEntry_t {
-	uint32_t sleep_from;      ///< time at which sleep has been requested
-	uint32_t interval;        ///< amount of time sleep shall take
-	uint8_t thread_id;        ///< thread ID which requested the sleep
-};
-
 // Kernel private functions and variables, not part of any header
 extern struct OS_core_state_t core[OS_NUM_CORES];
 extern struct TimerEntry_t sleepers[SLEEPERS_MAX];
@@ -22,7 +16,7 @@ CTEST_DATA(os_sched_timing_callback) {
 CTEST_SETUP(os_sched_timing_callback) {
     memset(&os_threads, 0, sizeof(os_threads));
     core[0].thread_current = 0;
-    memset(&sleepers, 0, sizeof(sleepers));
+    memset(&sleepers, 0xFF, sizeof(sleepers));
 }
 
 CTEST2(os_sched_timing_callback, round_robin_same_prio) {
@@ -63,6 +57,7 @@ CTEST2(os_sched_timing_callback, set_itimer) {
     os_threads[0].priority = 32;
     os_threads[1].priority = 48;
 
+    // Nothing happens
     os_sched_timing_callback(2500);
 
     ASSERT_EQUAL(core[0].thread_current, 0);

--- a/src/os/kernel/tests/os_setitimer.c
+++ b/src/os/kernel/tests/os_setitimer.c
@@ -3,13 +3,6 @@
 #include <ctest.h>
 #include <arch/corelocal.h>
 
-struct TimerEntry_t {
-	uint32_t sleep_from;      ///< time at which sleep has been requested
-	uint32_t interval;        ///< amount of time sleep shall take
-	uint8_t thread_id;        ///< thread ID which requested the sleep
-};
-
-
 // Kernel private functions and variables, not part of any header
 extern bool timing_provider_delay_called;
 extern long timing_provider_delay_us;
@@ -32,7 +25,7 @@ CTEST2(os_setitimer, add_interval_timer) {
     ASSERT_EQUAL(rv, 0);
     ASSERT_EQUAL(timing_provider_delay_called, false);
     ASSERT_EQUAL(sleepers[0].thread_id, 4);
-    ASSERT_EQUAL(sleepers[0].interval, (1 << 31) | 10000U);
+    ASSERT_EQUAL(sleepers[0].interval, 10000U);
 }
 
 CTEST2(os_setitimer, cancel_interval_timer) {

--- a/src/os/kernel/tests/os_usleep.c
+++ b/src/os/kernel/tests/os_usleep.c
@@ -3,18 +3,12 @@
 #include <ctest.h>
 #include <arch/corelocal.h>
 
-struct TimerEntry_t {
-	uint32_t sleep_from;      ///< time at which sleep has been requested
-	uint32_t interval;        ///< amount of time sleep shall take
-	uint8_t thread_id;        ///< thread ID which requested the sleep
-};
-
-
 // Kernel private functions and variables, not part of any header
 extern bool timing_provider_delay_called;
 extern long timing_provider_delay_us;
 extern struct OS_core_state_t core[OS_NUM_CORES];
 extern struct TimerEntry_t sleepers[SLEEPERS_MAX];
+extern struct OS_thread_t os_threads[OS_THREADS];
 
 CTEST_DATA(os_usleep) {
 };
@@ -22,6 +16,10 @@ CTEST_DATA(os_usleep) {
 CTEST_SETUP(os_usleep) {
     timing_provider_delay_called = false;
     core[0].thread_current = 4;
+    for (unsigned q = 0; q < OS_THREADS; ++q)
+    {
+        os_threads[q].state = q == core[0].thread_current ? THREAD_STATE_RUNNING : THREAD_STATE_READY;
+    }
 
     os_timer_init();
 }
@@ -32,6 +30,7 @@ CTEST2(os_usleep, busy_wait) {
     ASSERT_EQUAL(rv, 0);
     ASSERT_EQUAL(timing_provider_delay_called, true);
     ASSERT_EQUAL(timing_provider_delay_us, 100);
+    ASSERT_EQUAL(os_threads[4].state, THREAD_STATE_RUNNING);
 }
 
 CTEST2(os_usleep, scheduled_event) {
@@ -51,12 +50,23 @@ CTEST2(os_usleep, reschedule_event) {
     ASSERT_EQUAL(sleepers[0].thread_id, 4);
     ASSERT_EQUAL(sleepers[0].interval, 10000);
 
+    // os_usleep suspended this thread, make it running again
+    // so we can simulate resetting schedule for os_usleep for this thread
+    core[0].thread_current = 4;
+    os_threads[4].state = THREAD_STATE_RUNNING;
+
     rv = os_usleep(9876);
 
     ASSERT_EQUAL(rv, 0);
     ASSERT_EQUAL(timing_provider_delay_called, false);
     ASSERT_EQUAL(sleepers[0].thread_id, 4);
     ASSERT_EQUAL(sleepers[0].interval, 9876);
+
+    // This should end up as a busywait, no change to
+    // sleeper table.
+
+    core[0].thread_current = 4;
+    os_threads[4].state = THREAD_STATE_RUNNING;
 
     rv = os_usleep(150);
 
@@ -71,6 +81,7 @@ CTEST2(os_usleep, schedule_multiple_threads) {
     ASSERT_EQUAL(sleepers[0].thread_id, 4);
 
     core[0].thread_current = 3;
+    os_threads[3].state = THREAD_STATE_RUNNING;
     rv = os_usleep(10000);
     ASSERT_EQUAL(rv, 0);
     ASSERT_EQUAL(sleepers[0].thread_id, 4);
@@ -82,10 +93,9 @@ CTEST2(os_usleep, cancel_multiple_threads) {
     ASSERT_EQUAL(rv, 0);
 
     core[0].thread_current = 3;
+    os_threads[3].state = THREAD_STATE_RUNNING;
     rv = os_usleep(10000);
     ASSERT_EQUAL(rv, 0);
 
     core[0].thread_current = 4;
-    
-
 }

--- a/src/os/kernel/timer.h
+++ b/src/os/kernel/timer.h
@@ -9,6 +9,31 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/* List of various timer types supported by this framework.
+ * For most part, the most important characteristic is if
+ * the timer is periodic or not.
+ *
+ * This is decided by if the timer type is *above* or *below*
+ * the TIMER_PERIODIC type.
+ */
+enum eSleepType {
+    TIMER_SLEEP	= 0,
+    TIMER_TIMEOUT,
+    TIMER_PERIODIC,						// Marks the first periodic timer type
+    TIMER_INTERVAL = TIMER_PERIODIC,
+};
+
+/** Description of one sleep request.
+ * Contains details required to calculate when the next sleep interrupt shall happen
+ * and to determine which request shall be the next.
+ */
+struct TimerEntry_t {
+    uint32_t sleep_from;      ///< time at which sleep has been requested
+    uint32_t interval;        ///< amount of time sleep shall take
+    uint8_t thread_id;        ///< thread ID which requested the sleep
+    uint8_t timer_type;       ///< type of sleep performed
+};
+
 /** Kernel implementation of usleep() syscall.
  * See \ref usleep for details on arguments.
  */


### PR DESCRIPTION
Current timer infrastructure has only two types of timers which are hard-coded into timer infrastructure:

* sleep timer
* interval alarm timer

Their semantics is hard-coded and cannot be changed. If any other kind of timer is needed (e.g. call timeout timer), this can't be implemented.

Update the timer infrastructure in a way that more types of timers can be added with their specific handling being defined either directly in the timer subsystem, or later externally via callbacks.

This change provides an enum for timer type, partitioning timers to non-periodic one-shot timers and to periodically repeating timers.

Sleep timer and interval alarm timer are ported to the new infrastructure.