### PR TITLE
Wait for object: implement timeouts

### DIFF
--- a/include/cmrx/defines.h
+++ b/include/cmrx/defines.h
@@ -47,6 +47,10 @@
 #define E_IN_TOO_DEEP			11
 /// Too many pending notifications for differnt objects
 #define E_OUT_OF_NOTIFICATIONS  12
+/// Scheduler yield is required
+#define E_YIELD                 13
+/// Operation timed out
+#define E_TIMEOUT               14
 /// Internal error. No more free threads
 #define E_OUT_OF_THREADS        0xFF
 /** @} */

--- a/include/cmrx/ipc/notify.h
+++ b/include/cmrx/ipc/notify.h
@@ -46,8 +46,6 @@ __SYSCALL int notify_object(const void * object);
  *                disables timeout and the call waits indefinitely.
  * @returns E_OK if notification has arrived. E_TIMEOUT if notification
  * did not arrive before the timeout interval has passed.
- * @note Timeouts are not supported as of now. Syscall returns E_NOTAVAIL
- * if timeout value other than 0 is supplied to the call.
  */
 __SYSCALL int wait_for_object(const void * object, uint32_t timeout);
 

--- a/include/extra/queue_server/queue.h
+++ b/include/extra/queue_server/queue.h
@@ -119,6 +119,23 @@ bool queue_send(struct Queue * queue, const void * data);
 bool queue_send_silent(struct Queue * queue, const void * data);
 
 
+/** Receive data from queue with timeout.
+ *
+ * This will copy the oldest data out of the queue. If queue is
+ * empty then this call will block until queue is filled with data
+ * or until specified amount of time passed with no new data in the
+ * queue.
+ *
+ * @param [in] queue pointer to queue data is retrieved from
+ * @param [out] data pointer to place where data will be written
+ * @param [in] timeout_us amount of time to wait for the data. If 0
+ * is passed as timeout, then the function will wait indefinitely.
+ * @returns true if data were read from queue. Returns false in
+ * case specified amount of time elapsed and no new data is available.
+ */
+
+bool queue_receive_timeout(struct Queue * queue, void * data, uint32_t timeout_us);
+
 /** Receive data from queue.
  *
  * This will copy the oldest data out of the queue. If queue is
@@ -130,7 +147,10 @@ bool queue_send_silent(struct Queue * queue, const void * data);
  * @returns true. Returns false in case spurious interrupt occurred
  * and queue is still empty.
  */
-bool queue_receive(struct Queue * queue, void * data);
+static inline bool queue_receive(struct Queue * queue, void * data)
+{
+  return queue_receive_timeout(queue, data, 0);
+}
 
 /** Returns queue status.
  *

--- a/src/extra/queue_server/tests/test_queue_server.c
+++ b/src/extra/queue_server/tests/test_queue_server.c
@@ -123,7 +123,7 @@ CTEST2(queue_server, queue_write_read) {
 
     rv = queue_receive(&queue.q, buffer2);
 
-    ASSERT_EQUAL(wait_for_object_called, false);
+    ASSERT_EQUAL(wait_for_object_called, true);
     ASSERT_EQUAL(rv, true);
 
     cmp = memcmp(buffer, buffer2, TEST_QUEUE_ITEM_SIZE);

--- a/src/extra/queue_server/tests/test_queue_server.c
+++ b/src/extra/queue_server/tests/test_queue_server.c
@@ -1,6 +1,7 @@
 #include <ctest.h>
 #include <extra/queue_server/queue.h>
 #include <string.h>
+#include <cmrx/defines.h>
 
 STATIC_QUEUE(queue, 256);
 
@@ -9,6 +10,10 @@ STATIC_QUEUE(queue, 256);
 
 static bool wait_for_object_called = false;
 static void * wait_for_object_addr = NULL;
+/// How long will it take to notification to arrive?
+/// If set to 0 (default), it will arrive immediately
+static uint32_t wait_for_object_notified_after = 0;
+static void (*wait_for_object_notified_worker_func)() = NULL;
 
 static bool notify_object_called = false;
 static void * notify_object_addr = NULL;
@@ -19,10 +24,35 @@ int notify_object(void * addr) {
     return 0;
 }
 
-int wait_for_object(void * addr, int timeout) {
+int wait_for_object(void * addr, uint32_t timeout) {
     wait_for_object_called = true;
     wait_for_object_addr = addr;
-    return 0;
+    if (timeout == 0)
+    {
+        return E_OK;
+    }
+    else
+    {
+        if (timeout > wait_for_object_notified_after)
+        {
+            if (wait_for_object_notified_worker_func != NULL)
+            {
+                wait_for_object_notified_worker_func();
+            }
+            else
+            {
+                // Asserted here? Your test is wrong! You need to pass a function
+                // to this variable that gets called to simulate late arriving
+                // notification!
+                ASSERT_NOT_EQUAL((unsigned long) wait_for_object_notified_worker_func, 0);
+            }
+            return E_OK;
+        }
+        else
+        {
+            return E_TIMEOUT;
+        }
+    }
 }
 
 CTEST_DATA(queue_server) {
@@ -217,4 +247,55 @@ CTEST2(queue_server, queue_not_full_when_not_full) {
 
     rv = queue_full(&queue.q);
     ASSERT_EQUAL(rv, false);
+}
+
+static void queue_timeout_late_data_arrival()
+{
+    unsigned char buffer[TEST_QUEUE_ITEM_SIZE] = { 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5 };
+
+    (void) queue_send(&queue.q, buffer);
+}
+
+static void queue_timeout_no_data_arrival()
+{
+    // this function intentionally left blank
+}
+
+CTEST2(queue_server, queue_timeout_times_out_with_data) {
+    unsigned char buffer[TEST_QUEUE_ITEM_SIZE] = { 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5 };
+
+    // Fake notification to be received after 50ms
+    wait_for_object_notified_after = 50000;
+    wait_for_object_notified_worker_func = queue_timeout_late_data_arrival;
+
+    // Wait for the notification for 25ms
+    int rv = queue_receive_timeout(&queue.q, buffer, 25000);
+
+    ASSERT_EQUAL(rv, false);
+}
+
+CTEST2(queue_server, queue_timeout_times_out_no_data) {
+    unsigned char buffer[TEST_QUEUE_ITEM_SIZE] = { 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5 };
+
+    // Fake notification to be received after 50ms
+    wait_for_object_notified_after = 50000;
+    wait_for_object_notified_worker_func = queue_timeout_no_data_arrival;
+
+    // Wait for the notification for 25ms
+    int rv = queue_receive_timeout(&queue.q, buffer, 25000);
+
+    ASSERT_EQUAL(rv, false);
+}
+
+CTEST2(queue_server, queue_timeout_data_arrives) {
+    unsigned char buffer[TEST_QUEUE_ITEM_SIZE] = { 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5, 0xA5 };
+
+    // Fake notification to be received after 25ms
+    wait_for_object_notified_after = 25000;
+    wait_for_object_notified_worker_func = queue_timeout_late_data_arrival;
+
+    // Wait for the notification for 50ms
+    int rv = queue_receive_timeout(&queue.q, buffer, 50000);
+
+    ASSERT_EQUAL(rv, true);
 }

--- a/src/os/kernel/isr.c
+++ b/src/os/kernel/isr.c
@@ -52,7 +52,7 @@ void isr_kill(Thread_t thread_id, uint32_t signal)
 
 void isr_notify_object(const void * object)
 {
-	os_notify_object(object, EVT_USERSPACE_NOTIFICATION);
+	os_notify_object(object, EVT_DEFAULT);
 }
 
 /** @} */

--- a/src/os/kernel/sched.c
+++ b/src/os/kernel/sched.c
@@ -388,7 +388,7 @@ static void cb_thread_join_notify(const void * object, Thread_t thread, Event_t 
     if (os_threads[thread].state == THREAD_STATE_WAITING
         && os_threads[thread].wait_object == object)
     {
-        if (event == EVT_THREAD_DONE)
+        if (event == EVT_DEFAULT)
         {
             os_set_syscall_return_value(thread, dead_thread->exit_status);
         }
@@ -406,7 +406,7 @@ int os_thread_join(uint8_t thread_id)
             os_threads[thread_id].state = THREAD_STATE_EMPTY;
             os_txn_done();
             return rv;
-           }
+        }
         else
         {
             uint8_t current_thread_id = os_get_current_thread();

--- a/src/os/kernel/timer.h
+++ b/src/os/kernel/timer.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "runtime.h"
 
 /* List of various timer types supported by this framework.
  * For most part, the most important characteristic is if
@@ -50,6 +51,27 @@ int os_setitimer(unsigned microseconds);
  * things will go wrong.
  */
 void os_timer_init();
+
+/** Find a slot for timed event and store it.
+ *
+ * This is actual execution core for both \ref os_usleep and \ref os_setitimer
+ * functions. It will find free slot or slot already occupied by calling thread
+ * and will set / update timeout values.
+ * @param microseconds time for which thread should sleep / wait for event
+ * @param type type of timed event to set up
+ * @returns error status. 0 means no error.
+ */
+int os_set_timed_event(unsigned microseconds, enum eSleepType type);
+
+/** Cancels existing timed event.
+ *
+ * This function is only accessible for periodic timers externally. It
+ * allows cancelling of interval timers set previously.
+ * @param owner thread which shall own the interval timer
+ * @param type type of the event to be cancelled
+ * @return 0 if operation performed succesfully.
+ */
+int os_cancel_timed_event(Thread_t owner, enum eSleepType type);
 
 /** Provide information on next scheduled event.
  *


### PR DESCRIPTION
Wait for object syscall did contain timeout argument but up until now the call returned E_NOTAVAIL if timeout was any value different than zero.

Now timeout value can be specified in the call to wait, which will configure timer that aborts the wait for notification and returns E_TIMEOUT instead.

Substantial rework of the notification framework is part of this change as the actual handling of what happens when any notification arrives is up on the callback now. This made the callback a mandatory part of the framework unlike until now, callback might not be provided.