### PR TITLE
Fix/Change: STATIC_QUEUE declares type rather than variable

### DIFF
--- a/include/extra/queue_server/queue.h
+++ b/include/extra/queue_server/queue.h
@@ -56,20 +56,20 @@ struct BasicQueue {
   };
 };
 
-/** Create queue with custom storage allocation size.
- * This is a helper macro that defines queue with developer-specified size
+/** Create queue type with custom storage allocation size.
+ * This is a helper macro that defines type for queue with developer-specified size
  * of the queue data storage. Suitable for cases where fixed allocation size
  * of 256 bytes of @ref BasicQueue is either too much or too little.
  * @param name resulting name of queue variable
  * @param size size of the buffer in bytes
  */
-#define STATIC_QUEUE(name, size) \
-struct {\
+#define STATIC_QUEUE_T(name, size) \
+typedef struct {\
     union {\
         struct Queue q;\
         unsigned char buffer[sizeof(struct Queue) + size];\
     };\
-} name;
+} name
 #pragma GCC diagnostic pop
 
 //#define unpack_queue(__q) _Generic((__q), struct Queue * : (__q), default: ((__q)->q))

--- a/src/extra/queue_server/tests/test_queue_server.c
+++ b/src/extra/queue_server/tests/test_queue_server.c
@@ -3,7 +3,8 @@
 #include <string.h>
 #include <cmrx/defines.h>
 
-STATIC_QUEUE(queue, 256);
+STATIC_QUEUE_T(Queue_t, 256);
+Queue_t queue;
 
 #define TEST_QUEUE_DEPTH 16
 #define TEST_QUEUE_ITEM_SIZE 12


### PR DESCRIPTION
The old behavior of STATIC_QUEUE macro was to define a variable. This is all nice and compact, but scales poorly if you need to access the queue from more than one compilation unit.

Thus this macro has been changed to macro STATIC_QUEUE_T which declares a type instead of variable. Thus the variable has to be defined by the developer.

The advantage of this approach is that you can declare the queue type in a header and then define / extern variables as needed in modules.

This is a breaking change for all the code which was already relying on STATIC_QUEUE.

In order to reveal such code early, we don't provide macro for backwards compatibility.