### PR TITLE
Hotfix: Fix wrong/missing use of transactions in kernel

### DIFF
--- a/src/os/kernel/notify.h
+++ b/src/os/kernel/notify.h
@@ -60,7 +60,7 @@ void os_notify_init();
  * E_NOTAVAIL if thread is not waiting for *any* object and E_YIELD if
  * scheduler yield may be required.
  */
-int os_notify_thread(Thread_t thread_id, Event_t event);
+int os_notify_thread(Thread_t thread_id, int candidate_timer, Event_t event);
 
 /** Resume one thread that are waiting for this object.
  * This function will find one single thread which is waiting for this particular

--- a/src/os/kernel/runtime.h
+++ b/src/os/kernel/runtime.h
@@ -58,7 +58,7 @@ typedef int Event_t;
 
 /** Prototype for function that handles thread wakeup on notification.
  */
-typedef void (WaitHandler_t)(const void *, Thread_t, Event_t);
+typedef void (WaitHandler_t)(const void *, Thread_t, int, Event_t);
 
 
 

--- a/src/os/kernel/sched.c
+++ b/src/os/kernel/sched.c
@@ -347,6 +347,22 @@ int os_thread_stop(uint8_t thread)
 	return E_INVALID;
 }
 
+struct OS_thread_t * os_thread_by_id(Thread_t id)
+{
+    if (id < OS_THREADS)
+    {
+        return &os_threads[id];
+    }
+
+    return NULL;
+}
+
+int os_thread_set_ready(struct OS_thread_t * thread)
+{
+    thread->state = THREAD_STATE_READY;
+    return 0;
+}
+
 int os_thread_continue(uint8_t thread)
 {
 	if (thread < OS_THREADS)
@@ -358,7 +374,7 @@ int os_thread_continue(uint8_t thread)
             {
                 if (os_txn_commit(txn, TXN_READWRITE) == E_OK) 
                 {
-                    os_threads[thread].state = THREAD_STATE_READY;
+                    os_thread_set_ready(&os_threads[thread]);
                     os_txn_done();
                 }
                 os_sched_yield();
@@ -382,7 +398,7 @@ int os_setpriority(uint8_t priority)
 	return 0;
 }
 
-static void cb_thread_join_notify(const void * object, Thread_t thread, Event_t event)
+static void cb_thread_join_notify(const void * object, Thread_t thread, int sleeper_id, Event_t event)
 {
     struct OS_thread_t * dead_thread = (struct OS_thread_t *) object;
     if (os_threads[thread].state == THREAD_STATE_WAITING

--- a/src/os/kernel/sched.h
+++ b/src/os/kernel/sched.h
@@ -159,4 +159,8 @@ int os_thread_migrate(uint8_t thread_id, int target_core);
  */
 uint32_t os_shutdown();
 
+struct OS_thread_t * os_thread_by_id(Thread_t id);
+
+int os_thread_set_ready(struct OS_thread_t * thread);
+
 /** @} */

--- a/src/os/kernel/tests/os_notify_wait_object.c
+++ b/src/os/kernel/tests/os_notify_wait_object.c
@@ -17,7 +17,7 @@ static Thread_t notify_thread = 0;
 static Event_t notify_event = 0;
 extern struct TimerEntry_t sleepers[SLEEPERS_MAX];
 
-extern void cb_syscall_notify_object(const void * object, Thread_t thread, Event_t event);
+extern void cb_syscall_notify_object(const void * object, Thread_t thread, int sleeper_id, Event_t event);
 
 #define DEFAULT_CALLBACK    cb_syscall_notify_object
 
@@ -112,7 +112,7 @@ CTEST2(os_notify_wait_object, os_wait_object_multiple) {
     ASSERT_EQUAL((long) os_threads[3].wait_callback, (long) DEFAULT_CALLBACK);
 }
 
-static void cb_object_notify(const void * object, Thread_t thread, Event_t event)
+static void cb_object_notify(const void * object, Thread_t thread, int sleeper_id, Event_t event)
 {
     notify_called = true;
     notify_object = object;

--- a/src/os/kernel/timer.h
+++ b/src/os/kernel/timer.h
@@ -35,6 +35,9 @@ struct TimerEntry_t {
     uint8_t timer_type;       ///< type of sleep performed
 };
 
+#define TIMER_INVALID_ID 0xFF
+
+
 /** Kernel implementation of usleep() syscall.
  * See \ref usleep for details on arguments.
  */
@@ -63,15 +66,33 @@ void os_timer_init();
  */
 int os_set_timed_event(unsigned microseconds, enum eSleepType type);
 
+/** Find a timer slot matchin owner thread and timer type.
+ *
+ * This will find a slot which bears the timer of given type for given thread.
+ * @param [in] owner thread ID which should own the timer
+ * @param [in] type type of the timer.
+ */
+int os_find_timer(Thread_t owner, enum eSleepType type);
+
 /** Cancels existing timed event.
  *
  * This function is only accessible for periodic timers externally. It
  * allows cancelling of interval timers set previously.
  * @param owner thread which shall own the interval timer
  * @param type type of the event to be cancelled
- * @return 0 if operation performed succesfully.
+ * @return 0 if operation performed successfully.
  */
 int os_cancel_timed_event(Thread_t owner, enum eSleepType type);
+
+/** Cancel existing sleeper.
+ *
+ * This function will cancel existing sleeper. It is useful
+ * for cases where you already know the identity of the sleeper
+ * in advance.
+ * @param sleeper ID of the sleeper being cancelled
+ * @return 0 is operation performed successfully
+ */
+int os_cancel_sleeper(int sleeper);
 
 /** Provide information on next scheduled event.
  *


### PR DESCRIPTION
This commit fixes multiple places where transactions were either not used, or were used incorrectly. By incorrect use of transaction, it is meant that nested transaction commits were executed.

CMRX kernel transaction subsystem does *NOT* support nested transactions so this behavior caused any outer transaction to run unprotected. These two effects combined caused problems in wait_for_object() with timeout defined where in certain cases it could happen that the notification has been delivered *just* before the wait would time out. This led to crash inside the kernel.

This fix has a nature of hotfix. It was decided to rework the internals of the kernel to support "object methods" approach. There the architecture of who is responsible for creating transactions should be cleaner leading to overall cleaner code. As this is quite some work, hotfix fixes crash for now with refactor coming in later.

In order to fix code that issued nested commits, some new code had to be developed that allows to break functions creating their own transactions into parts that don't need transaction to be committed and part that lives under existing committed transaction.

In the future the whole kernel should be rewritten to look like this.