### PR TITLE
Kernel: Fail if too many processes are declared

### DIFF
--- a/src/os/kernel/sched.c
+++ b/src/os/kernel/sched.c
@@ -559,7 +559,7 @@ void _os_start(uint8_t start_core)
 
 	for (unsigned q = 0; q < applications; ++q)
 	{
-		os_process_create(q, &app_definition[q]);
+		ASSERT(os_process_create(q, &app_definition[q]) == E_OK);
 	}
 
 	for (unsigned q = 0; q < threads; ++q)


### PR DESCRIPTION
Kernel has statically pre-allocated process table that cannot be resized in runtime. If there are too many applications/processes in the image, kernel would not create entries for some of them and threads belonging to these processes would fail at runtime due to no MPU configuration existing.

This adds assert into _os_start() that will stop kernel initialization if this situation happens.