### PR TITLE
Fix GCC 14 compilation errors

### DIFF
--- a/src/os/arch/arm/cmsis/arch/cortex.h
+++ b/src/os/arch/arm/cmsis/arch/cortex.h
@@ -148,7 +148,7 @@ asm ( \
  * @returns address of argument relative to exception frame
  */
 
-uint32_t * get_exception_arg_addr(uint32_t * frame, unsigned argno, bool fp_active);
+uint32_t * get_exception_arg_addr(ExceptionFrame * frame, unsigned argno, bool fp_active);
 
 /** Retrieve value of exception frame function call argument.
  *
@@ -157,7 +157,7 @@ uint32_t * get_exception_arg_addr(uint32_t * frame, unsigned argno, bool fp_acti
  * @param argno number of argument retrieved
  * @returns value of function argument
  */
-static inline unsigned get_exception_argument(uint32_t * frame, unsigned argno, bool fp_active)
+static inline unsigned get_exception_argument(ExceptionFrame * frame, unsigned argno, bool fp_active)
 {
 	uint32_t * arg_addr = get_exception_arg_addr(frame, argno, fp_active);
 	return *arg_addr;
@@ -170,7 +170,7 @@ static inline unsigned get_exception_argument(uint32_t * frame, unsigned argno, 
  * @param argno number of argument retrieved
  * @param value new value of function argument
  */
-static inline void set_exception_argument(uint32_t * frame, unsigned argno, unsigned value, bool fp_active)
+static inline void set_exception_argument(ExceptionFrame * frame, unsigned argno, unsigned value, bool fp_active)
 {
 	uint32_t * arg_addr = get_exception_arg_addr(frame, argno, fp_active);
 	*arg_addr = value;
@@ -195,7 +195,7 @@ static inline void set_exception_pc_lr(ExceptionFrame * frame, void * pc, void (
  * @param fp_active if true then floating point unit is actively used in the thread exception is for
  * @return address of duplicated exception frame
  */
-uint32_t * push_exception_frame(uint32_t * frame, unsigned args, bool fp_active);
+ExceptionFrame * push_exception_frame(ExceptionFrame * frame, unsigned args, bool fp_active);
 
 /** Creates space for additional arguments under exception frame.
  *
@@ -207,7 +207,7 @@ uint32_t * push_exception_frame(uint32_t * frame, unsigned args, bool fp_active)
  * @param fp_active if true then floating point unit is actively used in the thread exception is for
  * @returns address of shimmed exception frame.
  */
-uint32_t * shim_exception_frame(uint32_t * frame, unsigned args, bool fp_active);
+ExceptionFrame * shim_exception_frame(ExceptionFrame * frame, unsigned args, bool fp_active);
 
 /** Remove exception frame from thread's stack.
  *
@@ -218,7 +218,7 @@ uint32_t * shim_exception_frame(uint32_t * frame, unsigned args, bool fp_active)
  * @param fp_active if true then floating point unit is actively used in the thread exception is for
  * @return new address of stack top after frame has been removed from it
  */
-uint32_t * pop_exception_frame(uint32_t * frame, unsigned args, bool fp_active);
+ExceptionFrame * pop_exception_frame(ExceptionFrame * frame, unsigned args, bool fp_active);
 
 /** Get value of process LR
  * @return top of application stack

--- a/src/os/arch/arm/cmsis/arch/runtime.h
+++ b/src/os/arch/arm/cmsis/arch/runtime.h
@@ -13,9 +13,11 @@ struct OS_thread_t;
  * space for FPU state being saved.
  */
 #if __FPU_USED
+
 void os_thread_initialize_arch(struct OS_thread_t * thread);
 void os_save_fpu_context(struct OS_thread_t * thread);
 void os_load_fpu_context(struct OS_thread_t * thread);
+bool os_fpu_exception_frame(void);
 
 #define os_save_exc_return(thread)      thread->arch.exc_return = (uint32_t) __get_LR()
 #define os_load_exc_return(thread)      __set_LR((void *) thread->arch.exc_return)
@@ -38,11 +40,13 @@ void os_init_core(unsigned core_id);
 #   define os_load_exc_return(thread)
 
 #   define os_is_thread_using_fpu(thread) (false)
+#   define os_fpu_exception_frame() (false)
 
 
 #   define os_init_arch(x)
 #   define os_init_core(x)
 #endif
+
 
 /** ARM-specific architecture state of a thread.
  * This structure holds additional state needed by the

--- a/src/os/arch/arm/cortex.c
+++ b/src/os/arch/arm/cortex.c
@@ -99,21 +99,6 @@ inline void os_request_context_switch(bool activate)
 	__DSB();
 }
 
-/** Get value of process LR
- * @return top of application stack
- */
-ALWAYS_INLINE void * __get_SP(void)
-{
-	void * sp;
-	asm volatile(
-		".syntax unified\n\t"
-		"MOV %0, SP\n\t"
-		: "=r" (sp)
-	);
-
-	return sp;
-}
-
 uint32_t os_perform_thread_switch(uint32_t LR);
 
 /** Wrapper for for Pending service interrupt handler.

--- a/src/os/arch/arm/mpu.c
+++ b/src/os/arch/arm/mpu.c
@@ -50,16 +50,6 @@ void hard_fault_handler(void)
 	ASSERT(0);
 }
 
-void mem_manage_handler(void)
-{
-	ASSERT(0);
-}
-
-static inline uint8_t log_2(uint32_t num)
-{
-	return __builtin_ctz(num);
-}
-
 /** Enable memory protection.
  * This routine enables memory protection with standard memory setup
  * for kernel purposes. This means that any privileged code has full

--- a/src/os/arch/arm/rpc.c
+++ b/src/os/arch/arm/rpc.c
@@ -33,8 +33,12 @@ int os_rpc_call(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
     (void) arg1;
     (void) arg2;
     (void) arg3;
-	const bool fpu_used = os_is_thread_using_fpu(os_get_current_thread());
-
+	#if __FPU_USED
+	Thread_t current_thread = os_get_current_thread();
+	const bool fpu_used = os_is_thread_using_fpu(current_thread);
+	#else
+	const bool fpu_used = false;
+	#endif
 	ExceptionFrame * local_frame = (ExceptionFrame *) __get_PSP();
 	sanitize_psp((uint32_t *) local_frame);
 	RPC_Service_t * service = (RPC_Service_t *) get_exception_argument(local_frame, 4, fpu_used);
@@ -103,7 +107,12 @@ int os_rpc_return(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
     (void) arg1;
     (void) arg2;
     (void) arg3;
-	const bool fpu_used = os_is_thread_using_fpu(os_get_current_thread());
+#if __FPU_USED
+	Thread_t current_thread = os_get_current_thread();
+	const bool fpu_used = os_is_thread_using_fpu(current_thread);
+#else
+	const bool fpu_used = false;
+#endif
 
 	ExceptionFrame * remote_frame = (ExceptionFrame *) __get_PSP();
 	sanitize_psp((uint32_t *) remote_frame);

--- a/src/os/arch/arm/rpc.c
+++ b/src/os/arch/arm/rpc.c
@@ -36,7 +36,7 @@ int os_rpc_call(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
 	Thread_t current_thread = os_get_current_thread();
 	bool fpu_used = os_is_thread_using_fpu(current_thread);
 
-	uint32_t * local_frame = (uint32_t *) __get_PSP();
+	ExceptionFrame * local_frame = (ExceptionFrame *) __get_PSP();
 	sanitize_psp((uint32_t *) local_frame);
 	RPC_Service_t * service = (RPC_Service_t *) get_exception_argument(local_frame, 4, fpu_used);
 	VTable_t * vtable = service->vtable;
@@ -62,7 +62,7 @@ int os_rpc_call(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
 	ASSERT(canary == 0xAA55AA55);
 #endif
 
-	uint32_t * remote_frame = push_exception_frame(local_frame, 2, fpu_used);
+	ExceptionFrame * remote_frame = push_exception_frame(local_frame, 2, fpu_used);
 	sanitize_psp((uint32_t *) remote_frame);
 
 	// remote frame arg [1 .. 4] = local frame arg [0 .. 3]
@@ -107,7 +107,7 @@ int os_rpc_return(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
 	Thread_t current_thread = os_get_current_thread();
 	bool fpu_used = os_is_thread_using_fpu(current_thread);
 
-	uint32_t * remote_frame = (uint32_t *) __get_PSP();
+	ExceptionFrame * remote_frame = (ExceptionFrame *) __get_PSP();
 	sanitize_psp((uint32_t *) remote_frame);
 #ifdef CMRX_RPC_CANARY
 	uint32_t canary = get_exception_argument(remote_frame, 5, fpu_used);
@@ -115,7 +115,7 @@ int os_rpc_return(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
 	ASSERT(canary == 0xAA55AA55);
 #endif
 
-	uint32_t * local_frame = pop_exception_frame(remote_frame, 2, fpu_used);
+	ExceptionFrame * local_frame = pop_exception_frame(remote_frame, 2, fpu_used);
 
 #if __FPU_USED
 	// Restore LR value saved into exception frame r0 slot

--- a/src/os/arch/arm/rpc.c
+++ b/src/os/arch/arm/rpc.c
@@ -33,8 +33,7 @@ int os_rpc_call(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
     (void) arg1;
     (void) arg2;
     (void) arg3;
-	Thread_t current_thread = os_get_current_thread();
-	bool fpu_used = os_is_thread_using_fpu(current_thread);
+	const bool fpu_used = os_is_thread_using_fpu(os_get_current_thread());
 
 	ExceptionFrame * local_frame = (ExceptionFrame *) __get_PSP();
 	sanitize_psp((uint32_t *) local_frame);
@@ -104,8 +103,7 @@ int os_rpc_return(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
     (void) arg1;
     (void) arg2;
     (void) arg3;
-	Thread_t current_thread = os_get_current_thread();
-	bool fpu_used = os_is_thread_using_fpu(current_thread);
+	const bool fpu_used = os_is_thread_using_fpu(os_get_current_thread());
 
 	ExceptionFrame * remote_frame = (ExceptionFrame *) __get_PSP();
 	sanitize_psp((uint32_t *) remote_frame);

--- a/src/os/arch/arm/rpc.c
+++ b/src/os/arch/arm/rpc.c
@@ -109,7 +109,7 @@ int os_rpc_return(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3)
     (void) arg3;
 #if __FPU_USED
 	Thread_t current_thread = os_get_current_thread();
-	const bool fpu_used = os_is_thread_using_fpu(current_thread);
+	bool fpu_used = os_is_thread_using_fpu(current_thread);
 #else
 	const bool fpu_used = false;
 #endif

--- a/src/os/arch/arm/runtime.c
+++ b/src/os/arch/arm/runtime.c
@@ -70,9 +70,10 @@ bool os_is_thread_using_fpu(Thread_t thread_id)
     return (os_threads[thread_id].arch.exc_return == EXC_RETURN_THREAD_PSP_FPU);
 }
 
-#endif
-
 bool os_fpu_exception_frame(void)
 {
     return os_is_thread_using_fpu(os_get_current_thread());
 }
+
+#endif
+

--- a/src/os/arch/arm/signal.c
+++ b/src/os/arch/arm/signal.c
@@ -35,7 +35,7 @@ __attribute__((naked)) static void os_fire_signal(uint32_t signal_mask, void *si
 
 void os_deliver_signal(struct OS_thread_t * thread, uint32_t signals)
 {
-	uint32_t * frame;
+	ExceptionFrame * frame;
 	uint32_t * new_sp;
 	bool fpu_used = os_fpu_exception_frame();
 
@@ -51,7 +51,7 @@ void os_deliver_signal(struct OS_thread_t * thread, uint32_t signals)
 		 * Thread state record is basically just an exception frame, which has
 		 * additional registers placed on top of it. 
 		 */
-		frame = thread->sp + 8;
+		frame = (ExceptionFrame *) (thread->sp + 8);
 		uint32_t * old_sp = thread->sp;
 		new_sp = old_sp - 6;
 		for (int q = 0; q < 8; ++q)


### PR DESCRIPTION
GCC 14 is more strict than GCC 12 used to be. Some stuff we did is not tolerated anymore. Patch up these items and clean the source code a bit given the output from clang-tidy.