### PR TITLE
Automation: Run clang-tidy automatically on commit / push

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,6 +1,6 @@
 name: Clang-Tidy
 on:
-  workflow-run:
+  workflow_run:
     workflows: [Unit Tests, Pull Request Unit Tests]
 
 jobs:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,0 +1,65 @@
+name: Clang-Tidy
+on:
+  workflow-run:
+    workflows: [Unit Tests, Pull Request Unit Tests]
+
+jobs:
+  clang-tidy-v6m:
+    name: Clang-Tidy ARMv6M
+    runs-on: ubuntu-latest
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v4.1.6
+       with:
+        submodules: 'true'
+
+     - name: Configure and Build Unit Tests
+       uses: threeal/cmake-action@main
+       with:
+        c-compiler: gcc
+        run-build: true
+        build-dir: static_analysis
+        options: CMRX_TARGET_PLATFORM=ARMv6M
+
+     - name: Run unit Tests
+       run: cmake --build static_analysis -- clang-tidy
+
+  clang-tidy-v7m:
+    name: Clang-Tidy ARMv6M
+    runs-on: ubuntu-latest
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v4.1.6
+       with:
+        submodules: 'true'
+
+     - name: Configure and Build Unit Tests
+       uses: threeal/cmake-action@main
+       with:
+        c-compiler: gcc
+        run-build: true
+        build-dir: static_analysis
+        options: CMRX_TARGET_PLATFORM=ARMv7M
+
+     - name: Run unit Tests
+       run: cmake --build static_analysis -- clang-tidy
+
+  clang-tidy-v7mf:
+    name: Clang-Tidy ARMv6M
+    runs-on: ubuntu-latest
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v4.1.6
+       with:
+        submodules: 'true'
+
+     - name: Configure and Build Unit Tests
+       uses: threeal/cmake-action@main
+       with:
+        c-compiler: gcc
+        run-build: true
+        build-dir: static_analysis
+        options: CMRX_TARGET_PLATFORM=ARMv7MF
+
+     - name: Run unit Tests
+       run: cmake --build static_analysis -- clang-tidy

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,7 +1,8 @@
 name: Clang-Tidy
 on:
   workflow_run:
-    workflows: [Unit Tests, Pull Request Unit Tests]
+    workflows: [ Unit Tests, Pull Request Unit Tests ]
+    types: [ completed ]
 
 jobs:
   clang-tidy-v6m:

--- a/cmake/clang-tidy.cmake
+++ b/cmake/clang-tidy.cmake
@@ -29,6 +29,8 @@ function(apply_clang_tidy TARGET)
 
     add_custom_target(tidy-${TARGET}
         COMMAND ${CLANGTIDY_EXECUTABLE}
+        --extra-arg=-I
+        --extra-arg=/usr/include
         -config-file=${CMRX_ROOT_DIR}/.clang-tidy
         -p ${CMAKE_BINARY_DIR}
         ${TARGET_SOURCES}

--- a/testing/clang-tidy/CMakeLists.txt
+++ b/testing/clang-tidy/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.18)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../cmake")
+
+if (NOT CMRX_TARGET_PLATFORM)
+    message(FATAL_ERROR "Use -DCMRX_TARGET_PLATFORM to select target platform to run clang-tidy on")
+elseif("${CMRX_TARGET_PLATFORM}" STREQUAL "ARMv6M")
+    add_compile_options(--target=arm-none-eabi)
+    set(CMSIS_ROOT ${CMAKE_SOURCE_DIR}/mock/cmsis)
+    set(DEVICE cortex-m0+)
+    set(CMSIS_LINKER_FILE ${CMAKE_SOURCE_DIR}/mock/cmsis/cortex-m0+.ld)
+    include(FindCMSIS)
+
+    set(CMRX_ARCH arm)
+    set(CMRX_HAL cmsis)
+elseif("${CMRX_TARGET_PLATFORM}" STREQUAL "ARMv7M")
+    add_compile_options(--target=arm-none-eabi)
+    set(CMSIS_ROOT ${CMAKE_SOURCE_DIR}/mock/cmsis)
+    set(DEVICE cortex-m3)
+    set(CMSIS_LINKER_FILE ${CMAKE_SOURCE_DIR}/mock/cmsis/cortex-m3.ld)
+    include(FindCMSIS)
+
+
+    set(CMRX_ARCH arm)
+    set(CMRX_HAL cmsis)
+elseif("${CMRX_TARGET_PLATFORM}" STREQUAL "ARMv7MF")
+    add_compile_options(--target=arm-none-eabi)
+    set(CMSIS_ROOT ${CMAKE_SOURCE_DIR}/mock/cmsis)
+    set(DEVICE cortex-m4f)
+    set(CMSIS_LINKER_FILE ${CMAKE_SOURCE_DIR}/mock/cmsis/cortex-m4f.ld)
+    include(FindCMSIS)
+
+    set(CMRX_ARCH arm)
+    set(CMRX_HAL cmsis)
+endif()
+
+project(cmrx-clang-tidy LANGUAGES ASM C)
+
+include(CMRX)
+
+add_subdirectory(../../ ${CMAKE_BINARY_DIR}/cmrx)

--- a/testing/clang-tidy/README.md
+++ b/testing/clang-tidy/README.md
@@ -1,0 +1,31 @@
+Clang-tidy dummy project
+========================
+
+This is a dummy CMake project that creates no executable targets or libraries. Its only purpose is to configure CMRX kernel for some specific architecture so that clang-tidy can be ran on that build.
+
+The reason why a build has to be configured for certain architecture is to find out which files actually belong to the build and which don't.
+
+For this purpose a very barebone mock of CMSIS headers is provided in mock subdirectory that gets used by this CMakeLists.txt.
+
+Using project
+-------------
+
+The use of this project is as follows:
+
+cmake -B <binary_dir> -DCMRX_TARGET_PLATFORM=<platform>
+cmake -B <binary_dir> clang-tidy
+
+Aside from normal prerequisites to configure and build CMRX kernel, this project requires clang-tidy to be present in the system path.
+
+The only target that is usable in this build is `clang-tidy` which executes clang-tidy on kernel sources.
+
+Supported target platforms
+--------------------------
+
+As code paths may differ for different platforms, this project supports following target platforms for kernel configuration. They are supported by mocked CMSIS headers so that code is syntactically correct. In order to configure the build for target platform argument `-DCMRX_TARGET_PLATFORM` **must** be passed to CMake when configuring the build otherwise configuration will fail. Valid values of this parameter are provided in the following table with their explanation.
+
+| CMRX_TARGET_PLATFORM | Platform properties |
+|----------------------|---------------------|
+| ARM_v6M              | ARM Cortex-M0+ CPU with MPU present |
+| ARM_v7M              | ARM Cortex-M3 CPU with MPU present |
+| ARM-v7MF             | ARM Cortex_M4 CPU with MPU and FPU both present |

--- a/testing/clang-tidy/mock/README.md
+++ b/testing/clang-tidy/mock/README.md
@@ -1,0 +1,6 @@
+CMSIS headers mock
+==================
+
+The content of this directory contains a minimal mock of CMSIS headers that allow clean run of clang-tidy with output equal to run on fully featured CMSIS.
+
+This mock is in no way supposed to allow build of either binaries or tests.

--- a/testing/clang-tidy/mock/cmsis/cortex-m0+.ld
+++ b/testing/clang-tidy/mock/cmsis/cortex-m0+.ld
@@ -1,0 +1,4 @@
+/* This file is intentionally left empty.
+ * The only purpose of its existence is to make FindCMSIS to believe it found
+ * a healthy installation of CMSIS-based HAL.
+ */

--- a/testing/clang-tidy/mock/cmsis/cortex-m3.ld
+++ b/testing/clang-tidy/mock/cmsis/cortex-m3.ld
@@ -1,0 +1,5 @@
+/* This file is intentionally left empty.
+ * The only purpose of its existence is to make FindCMSIS to believe it found
+ * a healthy installation of CMSIS-based HAL.
+ */
+

--- a/testing/clang-tidy/mock/cmsis/cortex-m4f.ld
+++ b/testing/clang-tidy/mock/cmsis/cortex-m4f.ld
@@ -1,0 +1,5 @@
+/* This file is intentionally left empty.
+ * The only purpose of its existence is to make FindCMSIS to believe it found
+ * a healthy installation of CMSIS-based HAL.
+ */
+

--- a/testing/clang-tidy/mock/cmsis/include/cortex-m0+.h
+++ b/testing/clang-tidy/mock/cmsis/include/cortex-m0+.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#define __ARM_ARCH_6M__
+
+#include "cortex.h"

--- a/testing/clang-tidy/mock/cmsis/include/cortex-m3.h
+++ b/testing/clang-tidy/mock/cmsis/include/cortex-m3.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define __ARM_ARCH_7M__
+
+#include "cortex.h"
+

--- a/testing/clang-tidy/mock/cmsis/include/cortex-m4f.h
+++ b/testing/clang-tidy/mock/cmsis/include/cortex-m4f.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define __ARM_ARCH_7M__
+
+#include "cortex.h"
+

--- a/testing/clang-tidy/mock/cmsis/include/cortex.h
+++ b/testing/clang-tidy/mock/cmsis/include/cortex.h
@@ -1,0 +1,160 @@
+#pragma once
+
+#include <stdint.h>
+
+#define __STATIC_FORCEINLINE static inline
+#define __enable_irq()
+#define __disable_irq()
+#define __set_CONTROL(x)
+#define __ISB()
+#define __DSB()
+
+extern volatile uint32_t __PSP;
+
+#define __set_PSP(x) __PSP = (x)
+#define __get_PSP(x) __PSP
+
+void NVIC_EnableIRQ(unsigned irq)
+{
+    (void) irq;
+}
+
+void NVIC_DisableIRQ(unsigned irq)
+{
+    (void) irq;
+}
+
+void __WFI()
+{
+}
+
+typedef struct {
+    volatile uint32_t AIRCR;
+#if defined __ARM_ARCH_7M__ || defined __ARM_ARCH_8M__
+    volatile uint32_t CFSR;
+#endif
+    volatile uint32_t ICSR;
+} SCB_Type;
+
+extern SCB_Type * SCB;
+
+#define SCB_AIRCR_VECTKEY_Pos              16U
+#define SCB_AIRCR_VECTKEY_Msk              (0xFFFFUL << SCB_AIRCR_VECTKEY_Pos)
+
+#define SCB_AIRCR_VECTKEYSTAT_Pos          16U
+#define SCB_AIRCR_VECTKEYSTAT_Msk          (0xFFFFUL << SCB_AIRCR_VECTKEYSTAT_Pos)
+
+#define SCB_AIRCR_ENDIANNESS_Pos           15U
+#define SCB_AIRCR_ENDIANNESS_Msk           (1UL << SCB_AIRCR_ENDIANNESS_Pos)
+
+#define SCB_AIRCR_SYSRESETREQ_Pos           2U
+#define SCB_AIRCR_SYSRESETREQ_Msk          (1UL << SCB_AIRCR_SYSRESETREQ_Pos)
+
+#define SCB_AIRCR_VECTCLRACTIVE_Pos         1U
+#define SCB_AIRCR_VECTCLRACTIVE_Msk        (1UL << SCB_AIRCR_VECTCLRACTIVE_Pos)
+
+#define SCB_ICSR_PENDSVSET_Pos             28U
+#define SCB_ICSR_PENDSVSET_Msk             (1UL << SCB_ICSR_PENDSVSET_Pos)
+
+#define SCB_ICSR_PENDSVCLR_Pos             27U
+#define SCB_ICSR_PENDSVCLR_Msk             (1UL << SCB_ICSR_PENDSVCLR_Pos)
+
+#if defined __ARM_ARCH_7M__ || defined __ARM_ARCH_8M__
+
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 0U)
+#define SCB_CFSR_IACCVIOL_Msk              (1UL
+
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_CFSR_MEMFAULTSR_Pos + 1U)
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)
+
+#define SCB_CFSR_MMARVALID_Pos             (SCB_CFSR_MEMFAULTSR_Pos + 7U)
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)
+
+#define SCB_CFSR_MEMFAULTSR_Pos             0U
+#define SCB_CFSR_MEMFAULTSR_Msk            (0xFFUL)
+
+#endif
+
+typedef struct {
+    volatile uint32_t CTRL;
+    volatile uint32_t RASR;
+    volatile uint32_t RBAR;
+    volatile uint32_t RNR;
+} MPU_Type;
+
+extern MPU_Type * MPU;
+
+
+#define MPU_TYPE_IREGION_Pos               16U
+#define MPU_TYPE_IREGION_Msk               (0xFFUL << MPU_TYPE_IREGION_Pos)
+
+#define MPU_TYPE_DREGION_Pos                8U
+#define MPU_TYPE_DREGION_Msk               (0xFFUL << MPU_TYPE_DREGION_Pos)
+
+#define MPU_TYPE_SEPARATE_Pos               0U
+#define MPU_TYPE_SEPARATE_Msk              (1UL
+
+
+#define MPU_CTRL_PRIVDEFENA_Pos             2U
+#define MPU_CTRL_PRIVDEFENA_Msk            (1UL << MPU_CTRL_PRIVDEFENA_Pos)
+
+#define MPU_CTRL_HFNMIENA_Pos               1U
+#define MPU_CTRL_HFNMIENA_Msk              (1UL << MPU_CTRL_HFNMIENA_Pos)
+
+#define MPU_CTRL_ENABLE_Pos                 0U
+#define MPU_CTRL_ENABLE_Msk                (1UL)
+
+
+#define MPU_RNR_REGION_Pos                  0U
+#define MPU_RNR_REGION_Msk                 (0xFFUL)
+
+
+#define MPU_RBAR_ADDR_Pos                   8U
+#define MPU_RBAR_ADDR_Msk                  (0xFFFFFFUL << MPU_RBAR_ADDR_Pos)
+
+#define MPU_RBAR_VALID_Pos                  4U
+#define MPU_RBAR_VALID_Msk                 (1UL << MPU_RBAR_VALID_Pos)
+
+#define MPU_RBAR_REGION_Pos                 0U
+#define MPU_RBAR_REGION_Msk                (0xFUL)
+
+
+#define MPU_RASR_ATTRS_Pos                 16U
+#define MPU_RASR_ATTRS_Msk                 (0xFFFFUL << MPU_RASR_ATTRS_Pos)
+
+#define MPU_RASR_XN_Pos                    28U
+#define MPU_RASR_XN_Msk                    (1UL << MPU_RASR_XN_Pos)
+
+#define MPU_RASR_AP_Pos                    24U
+#define MPU_RASR_AP_Msk                    (0x7UL << MPU_RASR_AP_Pos)
+
+#define MPU_RASR_TEX_Pos                   19U
+#define MPU_RASR_TEX_Msk                   (0x7UL << MPU_RASR_TEX_Pos)
+
+#define MPU_RASR_S_Pos                     18U
+#define MPU_RASR_S_Msk                     (1UL << MPU_RASR_S_Pos)
+
+#define MPU_RASR_C_Pos                     17U
+#define MPU_RASR_C_Msk                     (1UL << MPU_RASR_C_Pos)
+
+#define MPU_RASR_B_Pos                     16U
+#define MPU_RASR_B_Msk                     (1UL << MPU_RASR_B_Pos)
+
+#define MPU_RASR_SRD_Pos                    8U
+#define MPU_RASR_SRD_Msk                   (0xFFUL << MPU_RASR_SRD_Pos)
+
+#define MPU_RASR_SIZE_Pos                   1U
+#define MPU_RASR_SIZE_Msk                  (0x1FUL << MPU_RASR_SIZE_Pos)
+
+#define MPU_RASR_ENABLE_Pos                 0U
+#define MPU_RASR_ENABLE_Msk                (1UL)
+
+#define ARM_MPU_AP_NONE 0U
+#define ARM_MPU_AP_PRIV 1U
+#define ARM_MPU_AP_URO  2U
+#define ARM_MPU_AP_FULL 3U
+#define ARM_MPU_AP_PRO  5U
+#define ARM_MPU_AP_RO   6U
+
+#define EXC_RETURN_THREAD_PSP 0xFFFFFFFE
+


### PR DESCRIPTION
Add GitHub Action that creates three dummy builds of CMRX kernel for ARMv6M, ARMv7M and ARMv7M-F platforms and then launches clang-tidy on them.

Clang-tidy CMake module was augmented to provide additional include path so that standard library includes are found by clang-tidy.

Small barebone project and mocked CMSIS headers were creates so that these builds are syntactically correct and clang-tidy can do realistic reasoning on the code.