### PR TITLE
fix: Use subproject to run clang-tidy action

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -20,6 +20,7 @@ jobs:
         c-compiler: gcc
         run-build: true
         build-dir: static_analysis
+        source-dir: testing/clang-tidy
         options: CMRX_TARGET_PLATFORM=ARMv6M
 
      - name: Run unit Tests
@@ -40,6 +41,7 @@ jobs:
         c-compiler: gcc
         run-build: true
         build-dir: static_analysis
+        source-dir: testing/clang-tidy
         options: CMRX_TARGET_PLATFORM=ARMv7M
 
      - name: Run unit Tests
@@ -60,6 +62,7 @@ jobs:
         c-compiler: gcc
         run-build: true
         build-dir: static_analysis
+        source-dir: testing/clang-tidy
         options: CMRX_TARGET_PLATFORM=ARMv7MF
 
      - name: Run unit Tests


### PR DESCRIPTION
There is subproject in testing/clang-tidy project that needs to be used by CMake to configure build for running clang-tidy.