### PR TITLE
Fix: Buffer cursor corruption for queues > 256 bytes

### DIFF
--- a/src/extra/queue_server/queue.c
+++ b/src/extra/queue_server/queue.c
@@ -13,7 +13,7 @@ bool queue_send_silent(struct Queue * queue, const void * data)
 
     const unsigned size_limit = queue->depth * queue->item_size;
 
-    uint8_t cursor = queue->write_cursor;
+    unsigned cursor = queue->write_cursor;
     for (uint8_t q = 0; q < queue->item_size; ++q) {
         queue->content[cursor] = ((unsigned char *)data)[q];
         cursor = (cursor + 1) % size_limit;
@@ -52,7 +52,7 @@ bool queue_receive_timeout(struct Queue * queue, void * data, uint32_t timeout_u
 
     const unsigned size_limit = queue->depth * queue->item_size;
 
-    uint8_t cursor = queue->read_cursor;
+    unsigned cursor = queue->read_cursor;
     for (uint8_t q = 0; q < queue->item_size; ++q) {
         ((unsigned char *)data)[q] = queue->content[cursor];
         cursor = (cursor + 1) % size_limit;


### PR DESCRIPTION
If queues are larger than originally supported 256 bytes then code that reads and writes queues would occasionally corrupt both cursor positions and queue content.

This code changes internal cursor type from uint8_t to unsigned.