### PR TITLE
Add coverage reporting for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,3 +81,4 @@ if (BUILD_TESTING)
 endif()
 
 apply_clang_tidy(os)
+generate_coverage()

--- a/cmake/gcov.cmake
+++ b/cmake/gcov.cmake
@@ -1,0 +1,34 @@
+find_program(GCOV_EXECUTABLE gcov)
+
+if ("${GCOV_EXECUTABLE}" STREQUAL "GCOV_EXECUTABLE-NOTFOUND")
+    message(STATUS "GCOV not found! Linting disabled!")
+    message(STATUS "GCOV found: ${GCOV_EXECUTABLE}")
+endif()
+
+# Adds GCOV coverage to the target via compiler switches
+function(apply_gcov TARGET)
+    if ("${GCOV_EXECUTABLE}" STREQUAL "GCOV_EXECUTABLE-NOTFOUND")
+        return()
+    endif()
+
+    if (NOT TARGET ${TARGET})
+        message(FATAL_ERROR "apply_gcov: ${TARGET} is not a valid target name!")
+    endif()
+
+    target_compile_options(${TARGET} PRIVATE -ftest-coverage -fprofile-arcs -g)
+    target_link_options(${TARGET} INTERFACE -lgcov --coverage)
+endfunction()
+
+# Performs coverage report generation
+function(generate_coverage)
+    if ("${GCOV_EXECUTABLE}" STREQUAL "GCOV_EXECUTABLE-NOTFOUND")
+        return()
+    endif()
+
+    if (NOT TARGET coverage)
+        add_custom_target(coverage
+            COMMAND lcov --capture --directory ${CMAKE_BINARY_DIR} --output-file ${CMAKE_BINARY_DIR}/coverage.info
+            COMMAND genhtml ${CMAKE_BINARY_DIR}/coverage.info -output ${CMAKE_BINARY_DIR}/coverage
+            )
+    endif()
+endfunction()

--- a/cmake/unit_test_build.cmake
+++ b/cmake/unit_test_build.cmake
@@ -27,7 +27,11 @@ if (__UNIT_TESTING_BUILD)
     endif()
     set(UNIT_TESTING_BUILD 1)
     set(UNIT_TESTING 1)
+
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 endif()
+
+include(gcov)
 
 # Enable the build of CMRX kernel unit tests
 if (CMRX_UNIT_TESTS)

--- a/src/extra/queue_server/CMakeLists.txt
+++ b/src/extra/queue_server/CMakeLists.txt
@@ -7,5 +7,6 @@ if (NOT UNIT_TESTING_BUILD)
 endif()
 
 if (UNIT_TESTING_BUILD)
+    apply_gcov(queue)
     add_subdirectory(tests)
 endif()

--- a/src/os/kernel/CMakeLists.txt
+++ b/src/os/kernel/CMakeLists.txt
@@ -30,5 +30,6 @@ target_include_directories(os INTERFACE ${CMRX_ROOT_DIR}/include ${CMAKE_BINARY_
 # Just an alias
 add_library(cmrx ALIAS os)
 if (UNIT_TESTING_BUILD)
+    apply_gcov(os)
     add_subdirectory(tests)
 endif()


### PR DESCRIPTION
If production components (now the portable part of the OS kernel and the queue library) are build for testing purposes then these components are build with code coverage instrumentation turned on. All targets are linked with libgcov and when these tests are ran then coverage report is generated.

HTML version of the report can be generated using `coverage` target that is added to the build.

NB: Current test coverage is roughly 74% of kernel and 98% of queue server.