### PR TITLE
Fix: Thread entrypoint argument is invalid for booted thread

### DIFF
--- a/src/os/arch/arm/cmsis/arch/cortex.h
+++ b/src/os/arch/arm/cmsis/arch/cortex.h
@@ -66,10 +66,10 @@ _Static_assert(sizeof(ExceptionFrameFP) % 8 == 0, "The size of ExceptionFrameFP 
 ALWAYS_INLINE void __ISR_return()
 {
 		asm volatile(
-				"POP {R0, R1}\n\t"
-				"MOV R12, R0\n\t"
-				"MOV LR, R1\n\t"
 				"POP {R0, R1, R2, R3}\n\t"
+				"POP {R6, R7}\n\t"
+				"MOV R12, R6\n\t"
+				"MOV LR, R7\n\t"
 				"POP {R6, R7}\n\t"
 				"BX R6\n\t"
 				);
@@ -81,8 +81,8 @@ ALWAYS_INLINE void __ISR_return()
 ALWAYS_INLINE void __ISR_return()
 {
 		asm volatile(
-				"POP {R12, LR}\n\t"
 				"POP {R0, R1, R2, R3}\n\t"
+				"POP {R12, LR}\n\t"
 				"POP {R6, R7}\n\t"
 				"BX R6\n\t"
 				);


### PR DESCRIPTION
First executed thread is entered using software process that emulates ISR return. This is done in order to avoid having different setup for first thread and other threads.

The assembly routine which performed this "ISR return" was broken and popped register values from stack in wrong order. This caused that value which should end up in R0 (1st argument to the entry point) ended up somewhere else.

This caused the thread entry point function to work with random value instead of specified argument if and only if it was the thread that was the first to start. It did not happen if thread was first started via thread switcher.