### PR TITLE
Kernel: Rework the syscall calling convention

### DIFF
--- a/src/lib/irq.c
+++ b/src/lib/irq.c
@@ -4,12 +4,12 @@
 __SYSCALL int irq_enable(uint32_t irq)
 {
     (void) irq;
-    __SVC(SYSCALL_ENABLE_IRQ);
+    __SVC(SYSCALL_ENABLE_IRQ, irq);
 }
 
 __SYSCALL int irq_disable(uint32_t irq)
 {
     (void) irq;
-    __SVC(SYSCALL_DISABLE_IRQ);
+    __SVC(SYSCALL_DISABLE_IRQ, irq);
 }
 

--- a/src/lib/notify.c
+++ b/src/lib/notify.c
@@ -4,7 +4,7 @@
 __SYSCALL int notify_object(const void * object)
 {
 	(void) object;
-	__SVC(SYSCALL_NOTIFY_OBJECT);
+	__SVC(SYSCALL_NOTIFY_OBJECT, object);
 }
 
 __SYSCALL int notify_object2(const void * object, uint32_t flags)
@@ -17,7 +17,7 @@ __SYSCALL int wait_for_object(const void * object, uint32_t timeout)
 {
 	(void) object;
 	(void) timeout;
-	__SVC(SYSCALL_WAIT_FOR_OBJECT);
+	__SVC(SYSCALL_WAIT_FOR_OBJECT, object, timeout);
 }
 
 __SYSCALL int wait_for_object_value(uint8_t * object, uint8_t value, uint32_t timeout, uint32_t flags)

--- a/src/lib/rpc.c
+++ b/src/lib/rpc.c
@@ -13,5 +13,5 @@ __SYSCALL int _rpc_call(unsigned arg0, unsigned arg1, unsigned arg2, unsigned ar
     (void) service;
     (void) method;
     (void) canary;
-	__SVC(SYSCALL_RPC_CALL);
+	__SVC(SYSCALL_RPC_CALL, arg0, arg1, arg2, arg3, service, method);
 }

--- a/src/lib/signal.c
+++ b/src/lib/signal.c
@@ -5,12 +5,12 @@ __SYSCALL int signal(int signo, void (*sighandler)(uint32_t))
 {
     (void) signo;
     (void) sighandler;
-	__SVC(SYSCALL_SIGNAL);
+	__SVC(SYSCALL_SIGNAL, signo, sighandler);
 }
 
 __SYSCALL int kill(int thread, uint32_t signal)
 {
     (void) thread;
     (void) signal;
-	__SVC(SYSCALL_KILL);
+	__SVC(SYSCALL_KILL, thread, signal);
 }

--- a/src/lib/thread.c
+++ b/src/lib/thread.c
@@ -17,25 +17,25 @@ __SYSCALL int thread_create(int (*entrypoint)(void *), void * data, uint8_t prio
     (void) entrypoint;
     (void) data;
     (void) priority;
-	__SVC(SYSCALL_THREAD_CREATE);
+	__SVC(SYSCALL_THREAD_CREATE, entrypoint, data, priority);
 }
 
 __SYSCALL int thread_join(int thread)
 {
     (void) thread;
-	__SVC(SYSCALL_THREAD_JOIN);
+	__SVC(SYSCALL_THREAD_JOIN, thread);
 }
 
 __SYSCALL int thread_exit(int status)
 {
     (void) status;
-	__SVC(SYSCALL_THREAD_EXIT);
+	__SVC(SYSCALL_THREAD_EXIT, status);
 }
 
 __SYSCALL int setpriority(uint8_t priority)
 {
     (void) priority;
-	__SVC(SYSCALL_SETPRIORITY);
+	__SVC(SYSCALL_SETPRIORITY, priority);
 }
 
 /** @ingroup api_thread
@@ -50,7 +50,7 @@ __SYSCALL int setpriority(uint8_t priority)
  * entrypoint to be recorded as thread return value.
  * @param arg0 value returned by thread entrypoint
  */
-void os_thread_dispose(int arg0)
+int os_thread_dispose(int arg0)
 {
     (void) arg0;
 	// Do not place anything here. It will clobber R0 value!
@@ -58,7 +58,7 @@ void os_thread_dispose(int arg0)
 	// Normally, call to thread_exit would be here. But as we know that the way which
 	// led to os_thread_dispose being called results into R0 holding arg0, we may call
 	// syscall directly.
-	__SVC(SYSCALL_THREAD_EXIT);
+	__SVC(SYSCALL_THREAD_EXIT, arg0);
 	//thread_exit(arg0);
 	ASSERT(0);
 	// this should be called when thread returns

--- a/src/lib/timer.c
+++ b/src/lib/timer.c
@@ -4,11 +4,11 @@
 __SYSCALL int usleep(unsigned microseconds)
 {
     (void) microseconds;
-	__SVC(SYSCALL_USLEEP);
+	__SVC(SYSCALL_USLEEP, microseconds);
 }
 
 __SYSCALL int setitimer(unsigned microseconds)
 {
     (void) microseconds;
-	__SVC(SYSCALL_SETITIMER);
+	__SVC(SYSCALL_SETITIMER, microseconds);
 }

--- a/src/os/arch/arm/cmsis/arch/sysenter.h
+++ b/src/os/arch/arm/cmsis/arch/sysenter.h
@@ -5,6 +5,7 @@
 
 #if (!defined TESTING)
 
+
 /** Mark function as syscall entrypoint in userspace.
  * This gives the function some common attributes. Currently syscall entrypoint are
  * short functions which never get inlined and don't construct stack frame. This is
@@ -18,9 +19,10 @@
                   "BX LR\n\t" : : [immediate] "I" (no) : "r0")
 
 /** Perform syscall.
- * @param no number of syscall. 
+ * @param no number of syscall.
+ * @note ARM port will throw arguments to SVC call, they are already where they should be.
  */
-#define __SVC(no) ___SVC(no)
+#define __SVC(no, ...) ___SVC(no)
 
 #else
 


### PR DESCRIPTION
Update the way how porting layers are supposed to define the syscall.

The difference is that old way only communicated the syscall ID to the porting layer. New way provides a way how to communicate arguments as well. It is up on the porting layer if it uses this piece of information or not.

This makes the platform-independent code being usable by wider variety of porting layers.