### PR TITLE
Build system: Application creation is target-specific

### DIFF
--- a/cmake/CMRX.cmake
+++ b/cmake/CMRX.cmake
@@ -27,20 +27,5 @@ else()
     endif()
 endif()
 
-## Add firmware application definition
-# This function is a wrapper around add_library(), which will augment the library to act 
-# as a CMRX application.
-function(add_application NAME)
-	add_library(${NAME} STATIC EXCLUDE_FROM_ALL ${ARGN})
-	set_property(TARGET ${NAME} PROPERTY CMRX_IS_APPLICATION 1)
-    get_property(CMRX_ROOT_DIR GLOBAL PROPERTY CMRX_ROOT_DIR)
-	target_compile_definitions(${NAME} PRIVATE -D APPLICATION_NAME=${NAME})
-    add_custom_command(TARGET ${NAME} POST_BUILD
-        COMMAND ${CMRX_ROOT_DIR}/ld/checkapp.sh 
-        ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:${NAME}>
-        ${NAME}_instance
-        COMMENT "Checking application soundness"
-    )
-endfunction()
 
 

--- a/cmake/arch/arm/cmsis/CMRX.cmake
+++ b/cmake/arch/arm/cmsis/CMRX.cmake
@@ -92,4 +92,19 @@ function(target_add_applications TGT_NAME)
     endif()
 endfunction()
 
+## Add firmware application definition
+# This function is a wrapper around add_library(), which will augment the library to act
+# as a CMRX application.
+function(add_application NAME)
+	add_library(${NAME} STATIC EXCLUDE_FROM_ALL ${ARGN})
+	set_property(TARGET ${NAME} PROPERTY CMRX_IS_APPLICATION 1)
+    get_property(CMRX_ROOT_DIR GLOBAL PROPERTY CMRX_ROOT_DIR)
+	target_compile_definitions(${NAME} PRIVATE -D APPLICATION_NAME=${NAME})
+    add_custom_command(TARGET ${NAME} POST_BUILD
+        COMMAND ${CMRX_ROOT_DIR}/ld/checkapp.sh
+        ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:${NAME}>
+        ${NAME}_instance
+        COMMENT "Checking application soundness"
+    )
+endfunction()
 

--- a/cmake/arch/linux/posix/CMRX.cmake
+++ b/cmake/arch/linux/posix/CMRX.cmake
@@ -15,7 +15,16 @@ function(add_firmware FW_NAME)
 	target_link_options(${FW_NAME} PUBLIC -Wl,-Map=${FW_NAME}.map)
 endfunction()
 
-function(target_link_libraries TGT_NAME)
-    _target_link_libraries(${TGT_NAME} ${ARGN})
+function(target_add_applications TGT_NAME)
+    target_link_libraries(${TGT_NAME} ${ARGN})
 endfunction()
 
+## Add firmware application definition
+# This function is a wrapper around add_library(), which will augment the library to act
+# as a CMRX application.
+function(add_application NAME)
+	add_library(${NAME} OBJECT EXCLUDE_FROM_ALL ${ARGN})
+	set_property(TARGET ${NAME} PROPERTY CMRX_IS_APPLICATION 1)
+    get_property(CMRX_ROOT_DIR GLOBAL PROPERTY CMRX_ROOT_DIR)
+	target_compile_definitions(${NAME} PRIVATE -D APPLICATION_NAME=${NAME})
+endfunction()


### PR DESCRIPTION
The way how application is defined in the build system (what happens, what targets are appended to the main application library, what kind of library) may be target-specific. Move this logic from main CMake file into per-architecture CMake files.

This gives porting layer greater freedom to implement applications.