### PR TITLE
API: Application/thread definition platform-specific

### DIFF
--- a/src/os/arch/arm/cmsis/arch/application.h
+++ b/src/os/arch/arm/cmsis/arch/application.h
@@ -1,0 +1,37 @@
+#pragma once
+
+/* File intentionally left blank */
+#define CMRX_APPLICATION_INSTANCE_ATTRIBUTES __attribute__((sed, section(".applications") ))
+#define CMRX_THREAD_AUTOCREATE_ATTRIBUTES __attribute__((externally_visible, used, section(".thread_create") ))
+
+#define CMRX_APPLICATION_INSTANCE_CONSTRUCTOR(application) \
+extern void * __APPL_SYMBOL(application, data_start);\
+extern void * __APPL_SYMBOL(application, data_end);\
+extern void * __APPL_SYMBOL(application, bss_start);\
+extern void * __APPL_SYMBOL(application, bss_end);\
+extern void * __APPL_SYMBOL(application, vtable_start);\
+extern void * __APPL_SYMBOL(application, vtable_end);\
+extern void * __APPL_SYMBOL(application, __mmio_start);\
+extern void * __APPL_SYMBOL(application, __mmio_end);\
+extern void * __APPL_SYMBOL(application, shared_start);\
+extern void * __APPL_SYMBOL(application, shared_end);\
+\
+CMRX_APPLICATION_INSTANCE_ATTRIBUTES const struct OS_process_definition_t __APPL_SYMBOL(application, instance) = {\
+    {\
+        { &__APPL_SYMBOL(application, data_start), &__APPL_SYMBOL(application, data_end) },\
+        { &__APPL_SYMBOL(application, bss_start), &__APPL_SYMBOL(application, bss_end) },\
+        { __APPL_SYMBOL(application, mmio_start), __APPL_SYMBOL(application, mmio_end) },\
+        { __APPL_SYMBOL(application, mmio_2_start), __APPL_SYMBOL(application, mmio_2_end) },\
+        { &__APPL_SYMBOL(application, shared_start), &__APPL_SYMBOL(application, shared_end) }\
+    },\
+    { &__APPL_SYMBOL(application, vtable_start), &__APPL_SYMBOL(application, vtable_end) }\
+};
+
+#define CMRX_THREAD_AUTOCREATE_CONSTRUCTOR(application, entrypoint, data, priority, core) \
+CMRX_THREAD_AUTOCREATE_ATTRIBUTES const struct OS_thread_create_t __APPL_SYMBOL(application, thread_create_ ## entrypoint) = {\
+    &__APPL_SYMBOL(application, instance),\
+    entrypoint,\
+    data,\
+    priority,\
+    core\
+};

--- a/src/os/arch/linux/posix/arch/application.h
+++ b/src/os/arch/linux/posix/arch/application.h
@@ -1,0 +1,42 @@
+#pragma once
+
+extern void cmrx_posix_register_application(const struct OS_process_definition_t * process);
+extern void cmrx_posix_register_thread(const struct OS_thread_create_t * thread);
+
+#define CMRX_APPLICATION_INSTANCE_CONSTRUCTOR(application) \
+void * __APPL_SYMBOL(application, data_start) = (void *) 1;\
+void * __APPL_SYMBOL(application, data_end) = (void *) 1;\
+void * __APPL_SYMBOL(application, bss_start) = (void *) 1;\
+void * __APPL_SYMBOL(application, bss_end) = (void *) 1;\
+void * __APPL_SYMBOL(application, shared_start) = (void *) 1;\
+void * __APPL_SYMBOL(application, shared_end) = (void *) 1;\
+void * __APPL_SYMBOL(application, vtable_start) = (void *) 1;\
+void * __APPL_SYMBOL(application, vtable_end) = (void *) 1;\
+\
+const struct OS_process_definition_t __APPL_SYMBOL(application, instance) = {\
+    {\
+        { &__APPL_SYMBOL(application, data_start), &__APPL_SYMBOL(application, data_end) },\
+        { &__APPL_SYMBOL(application, bss_start), &__APPL_SYMBOL(application, bss_end) },\
+        { __APPL_SYMBOL(application, mmio_start), __APPL_SYMBOL(application, mmio_end) },\
+        { __APPL_SYMBOL(application, mmio_2_start), __APPL_SYMBOL(application, mmio_2_end) },\
+        { &__APPL_SYMBOL(application, shared_start), &__APPL_SYMBOL(application, shared_end) }\
+    },\
+    { &__APPL_SYMBOL(application, vtable_start), &__APPL_SYMBOL(application, vtable_end) }\
+};\
+__attribute__((constructor)) void __APPL_SYMBOL(application, inst_construct)(void)\
+{\
+    cmrx_posix_register_application(&__APPL_SYMBOL(application, instance));\
+}
+
+#define CMRX_THREAD_AUTOCREATE_CONSTRUCTOR(application, entrypoint, data, priority, core) \
+const struct OS_thread_create_t __APPL_SYMBOL(application, thread_create_ ## entrypoint) = {\
+    &__APPL_SYMBOL(application, instance),\
+    entrypoint,\
+    data,\
+    priority,\
+    core\
+}; \
+__attribute__((constructor)) void __APPL_SYMBOL(application, thread_create_ ## entrypoint ## _construct)(void)\
+{\
+    cmrx_posix_register_thread(&__APPL_SYMBOL(application, thread_create_ ## entrypoint));\
+}

--- a/src/os/arch/testing/arch/application.h
+++ b/src/os/arch/testing/arch/application.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define CMRX_THREAD_AUTOCREATE_CONSTRUTOR(application, entrypoint, data, priority, type)


### PR DESCRIPTION
Change the way how applications and threads are statically allocated. Up until now this code was hardcoded for all target platforms. Now the public API calls entities that are expected to be implemented by platform-specific code.

ARM code does what the old code was doing up until now. It creates structures that will end up in specific section that gets picked up by the linker script and its extents are recorded by symbols that are later used to iterate over it.

Linux code creates an array which is then processed by a generated function marked as constructor. This causes that the function is called before the main and can register these items.

Testing code does nothing as it is not using this facility.