### PR TITLE
Kernel: Merge arch-specific init and stack creation

### DIFF
--- a/src/os/arch/arm/cmsis/arch/runtime.h
+++ b/src/os/arch/arm/cmsis/arch/runtime.h
@@ -14,7 +14,6 @@ struct OS_thread_t;
  */
 #if __FPU_USED
 
-void os_thread_initialize_arch(struct OS_thread_t * thread);
 void os_save_fpu_context(struct OS_thread_t * thread);
 void os_load_fpu_context(struct OS_thread_t * thread);
 bool os_fpu_exception_frame(void);
@@ -33,7 +32,6 @@ void os_init_core(unsigned core_id);
 
 #else
 // These functions are not needed if FPU is not enabled, turn them into no-op
-#   define os_thread_initialize_arch(x)
 #   define os_save_fpu_context(x)
 #   define os_load_fpu_context(x)
 #   define os_save_exc_return(thread)

--- a/src/os/arch/arm/runtime.c
+++ b/src/os/arch/arm/runtime.c
@@ -6,14 +6,6 @@
 #include <arch/corelocal.h>
 
 #if __FPU_USED
-void os_thread_initialize_arch(struct OS_thread_t * thread)
-{
-    // By default, thread is restored into
-    // Thread mode, using PSP as a stack and
-    // without FPU
-    thread->arch.exc_return = EXC_RETURN_THREAD_PSP;
-}
-
 void os_save_fpu_context(struct OS_thread_t * thread)
 {
     ASSERT(thread->arch.exc_return == EXC_RETURN_THREAD_PSP || thread->arch.exc_return == EXC_RETURN_THREAD_PSP_FPU);

--- a/src/os/arch/testing/arch/runtime.h
+++ b/src/os/arch/testing/arch/runtime.h
@@ -1,8 +1,5 @@
 #pragma once
 
-// No special handling, declare as an empty macro
-#define os_thread_initialize_arch(x)
-
 struct Arch_State_t {
     /* intentionally left empty */
 };

--- a/src/os/arch/testing/sched.c
+++ b/src/os/arch/testing/sched.c
@@ -12,13 +12,13 @@ void os_boot_thread(Thread_t boot_thread)
     (void) boot_thread;
 }
 
-uint32_t * os_thread_populate_stack(int stack_id, unsigned stack_size, entrypoint_t * entrypoint, void * data)
+void os_thread_initialize_arch(struct OS_thread_t * thread, unsigned stack_size, entrypoint_t * entrypoint, void * data)
 {
-    (void) stack_id;
+    (void) thread;
     (void) stack_size;
     (void) entrypoint;
     (void) data;
-    return NULL;
+    return;
 }
 
 int os_process_create(Process_t process_id, const struct OS_process_definition_t * definition)

--- a/src/os/kernel/arch/runtime.h
+++ b/src/os/kernel/arch/runtime.h
@@ -4,14 +4,6 @@
  * @{
  */
 
-/** Finalize architecture-specific initialization of thread.
- * This routine is called when thread has been created. It has opportunity to
- * perform architecture-specific default-initialization of the thread.
- * @note To save some CPU cycles, you can define this function as an empty macro if it is not used.
- * In that case the @ref Arch_State_t should be an empty structure.
- */
-extern void os_thread_initialize_arch(struct OS_thread_t * thread);
-
 /** Architecture code-private part of thread record.
  * This structure holds the CPU-specific part of thread
  * state. It can be empty if architecture does not need

--- a/src/os/kernel/arch/sched.h
+++ b/src/os/kernel/arch/sched.h
@@ -6,16 +6,19 @@
 #include <kernel/runtime.h>
 #include <stdint.h>
 
-/** Populate stack of new thread so it can be executed.
- * Populates stack of new thread so that it can be executed with no
- * other actions required. Returns the address where SP shall point to.
- * @param stack_id ID of stack to be populated
+/** Perform architecture-specific thread initialization
+ * This function should perform the following actions:
+ * - Configure thread state so it can be executed immediately after this function is done
+ * - Set valid value into SP member, so the stack pointer can be set to valid value
+ * - Perform any architecture-specific steps needed to make thread executable
+ * - Set any architecture-specific settings
+ * @param thread pointer to structure describing the thread just being created
  * @param stack_size size of stack in 32-bit quantities
  * @param entrypoint address of thread entrypoint function
  * @param data address of data passed to the thread as its 1st argument
  * @returns Address to which the SP shall be set.
  */
-uint32_t * os_thread_populate_stack(int stack_id, unsigned stack_size, entrypoint_t * entrypoint, void * data);
+void os_thread_initialize_arch(struct OS_thread_t * thread, unsigned stack_size, entrypoint_t * entrypoint, void * data);
 
 /** Create process using process definition.
  * Takes process definition and initializes MPU regions for process out of it.

--- a/src/os/kernel/sched.c
+++ b/src/os/kernel/sched.c
@@ -459,7 +459,6 @@ int __os_thread_create(Process_t process, entrypoint_t * entrypoint, void * data
 	uint8_t thread_id = os_thread_alloc(process, priority);
     if (thread_id < OS_THREADS)
     {
-        os_thread_initialize_arch(&os_threads[thread_id]);
     	os_thread_construct(thread_id, entrypoint, data, core);
     }
     ASSERT(thread_id < OS_THREADS);
@@ -477,7 +476,7 @@ int os_thread_construct(Thread_t tid, entrypoint_t * entrypoint, void * data, ui
 			if (stack_id != 0xFFFFFFFF)
 			{
 				new_thread->stack_id = stack_id;
-                new_thread->sp = os_thread_populate_stack(stack_id, OS_STACK_DWORD, entrypoint, data);
+                os_thread_initialize_arch(new_thread, OS_STACK_DWORD, entrypoint, data);
                 new_thread->core_id = core_id;
 
 				new_thread->state = THREAD_STATE_READY;


### PR DESCRIPTION
Merge the call to architecture specific thread initialization and thread stack creation.

Both of these calls are thread-specific, get called at thread creation time and both of them are served by the porting layer.

The platform-specific thread initialization function is removed from the portin layer API.

By changing the arguments to thread stack creation function it can serve both purposes and the other function can be omitted from the porting layer altogether.

The ARM code merges the action of both functions together into one function, so it fills-in the stack in a way it can be started both by "booting" into it and by switching into it via PendSV.

The Linux code creates ucontext structures so the code can later use switch / swap context. No manipulation with stack is needed as the thread startup is deal with by context machinery internally.