### PR TITLE
Fix: Build break on ARMv6M chips

### DIFF
--- a/src/os/arch/arm/sched.c
+++ b/src/os/arch/arm/sched.c
@@ -35,7 +35,7 @@ void os_thread_initialize_arch(struct OS_thread_t * thread, unsigned stack_size,
     stack[stack_size - 1] = 0x01000000; // xPSR
 
     thread->sp = &stack[stack_size - 16];
-#ifdef __FPU_USED
+#if __FPU_USED
 	// By default, thread is restored into
 	// Thread mode, using PSP as a stack and
 	// without FPU


### PR DESCRIPTION
Macro __FPU_USED is either 1 or 0 depending on if FPU is present on chip or not. One place in the code was using this macro using #ifdef instead of #if which made the ARMv6M builds to break.