### PR TITLE
Fix: Rework Linux thread switching mechanism

### DIFF
--- a/src/os/arch/linux/clock.c
+++ b/src/os/arch/linux/clock.c
@@ -1,3 +1,5 @@
+#include "clock.h"
+
 #include <cmrx/clock.h>
 
 #include <signal.h>
@@ -7,49 +9,67 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "linux.h"
+#include <stdbool.h>
+
 
 /* Linux port of CMRX has one default timing provider bundled with kernel */
 
+/** Systick interval stored as value in ns */
 static long int systick_ns = 0;
+
+/** Systick interval stored as value in us */
 static int systick_us = 0;
+
+/** POSIX timer used to implement the systick */
 static timer_t systick_timer;
 
-void sigalrm_handler(int signo, siginfo_t *info, void *context)
+void sigalrm_handler(int signo)
 {
     os_sched_timing_callback(systick_us);
-    trigger_pendsv_if_needed();
 }
 
 void timing_provider_setup(int interval_ms)
 {
-    systick_ns = interval_ms * 1000000;
+    systick_ns = interval_ms * 100000;
     systick_us = interval_ms * 1000;
 
     struct sigaction act = { 0 };
-    act.sa_flags = SA_SIGINFO;
-    act.sa_sigaction = &sigalrm_handler;
+    act.sa_flags = 0;
+    act.sa_handler = &sigalrm_handler;
+    sigemptyset(&act.sa_mask);
+    sigaddset(&act.sa_mask, SIGUSR1);
 
     sigaction(SIGALRM, &act, NULL);
-    // expire in interval_ms and then every interval_ms
-    struct itimerspec systick = { { 0, systick_ns }, { 0, systick_ns } };
-    struct sigevent timer_ev;
-    timer_ev.sigev_signo = SIGALRM;
-    timer_ev.sigev_notify = SIGEV_SIGNAL;
-    timer_create(CLOCK_MONOTONIC, &timer_ev, &systick_timer);
-    timer_settime(systick_timer, 0, &systick, NULL);
 }
 
 void timing_provider_schedule(long delay_us)
 {
-    /* Intentionally left blank */
+    /* As of now this port is not tickless */
+    (void) delay_us;
+
+    static bool timer_started = false;
+
+    if (!timer_started)
+    {
+        // expire in interval_ms and then every interval_ms
+        struct itimerspec systick = { { 0, systick_ns }, { 0, systick_ns } };
+        struct sigevent timer_ev;
+        timer_ev.sigev_signo = SIGALRM;
+        timer_ev.sigev_notify = SIGEV_SIGNAL;
+        timer_create(CLOCK_MONOTONIC, &timer_ev, &systick_timer);
+        timer_settime(systick_timer, 0, &systick, NULL);
+        timer_started = true;
+    }
 }
 
 void timing_provider_delay(long delay_us)
 {
+    // We should make sure this won't call into CMRX usleep() syscall.
     usleep(delay_us);
 }
 
 long timing_get_current_cpu_freq(void)
 {
+    // What to return here?
     return 0;
 }

--- a/src/os/arch/linux/clock.h
+++ b/src/os/arch/linux/clock.h
@@ -1,0 +1,29 @@
+#pragma once
+
+/** @defgroup arch_linux_timing Linux timing provider
+ * @ingroup arch_linux
+ *
+ * This is the default (and the only) timing provider for the
+ * Linux target platform. This timing provider is built around
+ * SIGALRM being delivered based on timer that is set up on
+ * timing provider start and first schedule.
+ *
+ * This in turn calls kernel callback for timing actions.
+ *
+ * Due to the way how this provider is integrated into kernel
+ * it is made to be a fully integrated part of the kernel.
+ * It is unlikely that anyone would ever need to replace it.
+ *
+ * @{
+ */
+
+
+/** Timer handler.
+ * This handler will call the kernel timing callback.
+ * @param signo for internal use
+ */
+void sigalrm_handler(int signo);
+
+/**
+ * @}
+ */

--- a/src/os/arch/linux/linux.h
+++ b/src/os/arch/linux/linux.h
@@ -1,3 +1,33 @@
 #pragma once
 
+#include <kernel/runtime.h>
+
+/** @ingroup arch_linux
+ * @{
+ */
+
+/** Internal thread startup data structure
+ *
+ * Internal structure to communicate CMRX thread
+ * details to the routine which initiates Linux
+ * thread that hosts the CMRX thread.
+ */
+struct thread_startup_t {
+    int thread_id;              ///< CMRX thread ID
+    entrypoint_t * entry_point; ///< thread entry function as CMRX userspace sees it
+    void * entry_arg;           ///< argument to the entry function
+};
+
+/** Initiate thread switch sequence if it was requested.
+ * This function will initiate the thread switch sequence.
+ * Sequence is actually performed by other code, which runs
+ * in different thread. This function just sends a signal
+ * to run it.
+ *
+ * It is safe to call this function from any thread.
+ */
 void trigger_pendsv_if_needed();
+
+/**
+ * @}
+ */

--- a/src/os/arch/linux/posix/arch/application.h
+++ b/src/os/arch/linux/posix/arch/application.h
@@ -1,8 +1,55 @@
 #pragma once
 
+/** @ingroup arch_linux_impl
+ * @{
+ */
+
+/** Internal routine to register application with kernel.
+ * This routine is used by the static creation mechanism to
+ * register application with kernel. It will be called before
+ * the main() is executed. It puts application definition into
+ * list of known application definitions for the kernel to
+ * create this process upon kernel startup.
+ * @param process process definition structure
+ * @note This function is kernel-private and specific to Linux port
+ */
 extern void cmrx_posix_register_application(const struct OS_process_definition_t * process);
+
+/** Internal routine to register thread with kernel.
+ * This routine is used by the thread autostart mechanism to
+ * register thread with kernel. It will be called before
+ * the main() is executed. It puts thread definition into
+ * list of known thread definitions for the kernel to
+ * create this thread upon kernel startup.
+ * @param process thread definition structure
+ * @note This function is kernel-private and specific to Linux port
+ */
 extern void cmrx_posix_register_thread(const struct OS_thread_create_t * thread);
 
+/** @}
+ */
+
+/** @defgroup arch_linux Linux port
+ * @ingroup arch
+ * Linux port provides the ability to run CMRX-based environment hosted on
+ * ordinary Linux machine as a ordinary userspace process.
+ *
+ * Linux architecture support is an environment where CMRX scheduler
+ * and kernel API runs hosted as ordinary Linux process. Here CMRX uses
+ * Linux' own syscalls to implement functionality of the abstract machine.
+ *
+ * The environment which Linux-based environment creates encapsulates
+ * whole system into one process. All CMRX processes share common address
+ * space. This is similar to other architectures which CMRX currently
+ * supports.
+ * @{
+ */
+
+/** Linux port implementation of application creation macro.
+ *
+ * As of now this macro does nothing. It is here just to make
+ * this port conformal to the API.
+ */
 #define CMRX_APPLICATION_INSTANCE_CONSTRUCTOR(application) \
 void * __APPL_SYMBOL(application, data_start) = (void *) 1;\
 void * __APPL_SYMBOL(application, data_end) = (void *) 1;\
@@ -28,6 +75,15 @@ __attribute__((constructor)) void __APPL_SYMBOL(application, inst_construct)(voi
     cmrx_posix_register_application(&__APPL_SYMBOL(application, instance));\
 }
 
+/** Linux port implementation of thread autostart.
+ *
+ * Thread autostart is implemented by creating instance of structure
+ * describing thread to be created and creating a function that calls
+ * @ref cmrx_posix_register_thread. This function is marked as constructor
+ * which ensures it is called before the main is started.
+ *
+ * See @ref OS_THREAD_CREATE for more details in arguments.
+ */
 #define CMRX_THREAD_AUTOCREATE_CONSTRUCTOR(application, entrypoint, data, priority, core) \
 const struct OS_thread_create_t __APPL_SYMBOL(application, thread_create_ ## entrypoint) = {\
     &__APPL_SYMBOL(application, instance),\
@@ -40,3 +96,7 @@ __attribute__((constructor)) void __APPL_SYMBOL(application, thread_create_ ## e
 {\
     cmrx_posix_register_thread(&__APPL_SYMBOL(application, thread_create_ ## entrypoint));\
 }
+
+/**
+ * @}
+ */

--- a/src/os/arch/linux/posix/arch/runtime.h
+++ b/src/os/arch/linux/posix/arch/runtime.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <ucontext.h>
+#include <threads.h>
+#include <stdatomic.h>
+#include <pthread.h>
 
 #define os_init_core(x)
 
@@ -10,6 +13,9 @@ void os_thread_initialize_arch(struct OS_thread_t * thread, unsigned stack_size,
 void os_init_arch(void);
 
 struct Arch_State_t {
-    ucontext_t thread_context;
+    int block_pipe[2];  // [read_fd, write_fd]
+    volatile atomic_int is_suspended;
+    thrd_t sched_thread;
+    pthread_t sched_thread_id;
 };
 

--- a/src/os/arch/linux/static.c
+++ b/src/os/arch/linux/static.c
@@ -4,12 +4,21 @@
 #include <stdbool.h>
 #include <string.h>
 
+/** @ingroup arch_linux_impl
+ * @{
+ */
+
+/** Counter for known process definitions */
 static unsigned process_count = 0;
+
+/** Counter for autostarted threads */
 static unsigned thread_count = 0;
 
+/** Structure that holds information on process definitions */
 static struct OS_process_definition_t os_process_definitions[OS_PROCESSES];
-static struct OS_thread_create_t os_thread_definitions[OS_THREADS];
 
+/** Structure that holds information on autostarted threads */
+static struct OS_thread_create_t os_thread_definitions[OS_THREADS];
 
 void cmrx_posix_register_application(const struct OS_process_definition_t * process)
 {
@@ -32,6 +41,12 @@ void cmrx_posix_register_thread(const struct OS_thread_create_t * thread)
     memcpy(&os_thread_definitions[thread_count], thread, sizeof(struct OS_thread_create_t));
     thread_count++;
 }
+/** @}
+ */
+
+/** @ingroup arch_linux
+ * @{
+ */
 
 unsigned static_init_thread_count()
 {
@@ -53,4 +68,6 @@ const struct OS_process_definition_t * static_init_process_table()
     return os_process_definitions;
 }
 
-
+/**
+ * @}
+ */


### PR DESCRIPTION
The original concept of thread switching was based on context switching. The prototype implementation was working yet it was relying on undefined behavior of switching context inside signal handler. It turned out it doesn't work reliably.

Thus the thread switching mechanism was reworked to use Linux threads and enforce synchronization via sending signals.

This is actually a less hacky and more portable approach + it allows debugging of individual CMRX threads by host GDB as threads are mapped 1:1.

Port was extensively documented.