### PR TITLE
Fix: Make syscalls run in "kernel context"

### DIFF
--- a/src/os/arch/linux/clock.c
+++ b/src/os/arch/linux/clock.c
@@ -25,6 +25,7 @@ static timer_t systick_timer;
 
 void sigalrm_handler(int signo)
 {
+    (void) signo;
     os_sched_timing_callback(systick_us);
 }
 

--- a/src/os/arch/linux/linux.h
+++ b/src/os/arch/linux/linux.h
@@ -2,7 +2,7 @@
 
 #include <kernel/runtime.h>
 
-/** @ingroup arch_linux
+/** @ingroup arch_linux_impl
  * @{
  */
 
@@ -17,6 +17,7 @@ struct thread_startup_t {
     entrypoint_t * entry_point; ///< thread entry function as CMRX userspace sees it
     void * entry_arg;           ///< argument to the entry function
 };
+
 
 /** Initiate thread switch sequence if it was requested.
  * This function will initiate the thread switch sequence.

--- a/src/os/arch/linux/posix/arch/runtime.h
+++ b/src/os/arch/linux/posix/arch/runtime.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <ucontext.h>
 #include <threads.h>
 #include <stdatomic.h>
 #include <pthread.h>
@@ -12,10 +11,37 @@ struct OS_thread_t;
 void os_thread_initialize_arch(struct OS_thread_t * thread, unsigned stack_size, entrypoint_t * entrypoint, void * data);
 void os_init_arch(void);
 
+/** Syscall dispatch data structure
+ *
+ * Internal structure to dispatch arguments to
+ * syscall and return system call return value.
+ */
+struct syscall_dispatch_t {
+    long args[6];
+    long retval;
+    unsigned char syscall_id;
+};
+
+/** Linux port internal architecture state.
+ *
+ * This structure records thread state private to the Linux port.
+ * Here blocking primitives for synchronization of threads and
+ * system calls are recorded as well as block where information
+ * is passed down to the syscall and back from it.
+ */
 struct Arch_State_t {
+    /// Ends of pipe that is used to simulate thread preemption
     int block_pipe[2];  // [read_fd, write_fd]
+    /// Ends of pipe that is used to synchronize thread and syscall
+    int syscall_pipe[2]; // [read_fd, write_fd]
+    /// State information on if thread is suspended or not (unused)
     volatile atomic_int is_suspended;
+    /// C11 thread identifier of the Linux thread that supports this CMRX thread
     thrd_t sched_thread;
+    /// POSIX thread identifier of the Linux thread that support this CMRX thread
     pthread_t sched_thread_id;
+    /// Buffer for dispatching system calls to the kernel and return values back
+    /// to the userspace
+    struct syscall_dispatch_t syscall;
 };
 


### PR DESCRIPTION
In the old version of the code, syscalls were executed in the same context as the user code. While there is no memory isolation implemented in this port yet, this had no major effect except of the possibility that multiple threads could be in the kernel "context" at the same time and thread could be scheduled out of the CPU while being in kernel.

This is not supported by the CMRX kernel as the only scenario where multiple threads are in the kernel context at the same time is if the machine has multiple cores.

Thus the system call entry mechanism was rewritten in a way that system calls are dispatched to the "kernel thread". This way, only one thread can ever only be inside the kernel context at the same time.