### PR TITLE
Fix: silence unused parameter warning in notify_object2

### DIFF
--- a/src/lib/notify.c
+++ b/src/lib/notify.c
@@ -10,6 +10,7 @@ __SYSCALL int notify_object(const void * object)
 __SYSCALL int notify_object2(const void * object, uint32_t flags)
 {
 	(void) object;
+	(void) flags;
 	__SVC(SYSCALL_NOTIFY_OBJECT2);
 }
 


### PR DESCRIPTION
notify_object2() did not use the 'flags' parameter, which triggered -Wunused-parameter during builds. Cast to void to fix it.

Build warning:

In function 'notify_object2':
/path/to/cmrx/src/lib/notify.c:10:60: warning: unused parameter 'flags' [-Wunused-parameter]