### PR TITLE
Fix: ARM port warnings

### DIFF
--- a/src/os/arch/arm/cmsis/arch/application.h
+++ b/src/os/arch/arm/cmsis/arch/application.h
@@ -4,8 +4,8 @@
 #define CMRX_VTABLE_SPECIFIER __attribute__((section(".vtable."))) const
 
 /* File intentionally left blank */
-#define CMRX_APPLICATION_INSTANCE_ATTRIBUTES __attribute__((sed, section(".applications") ))
-#define CMRX_THREAD_AUTOCREATE_ATTRIBUTES __attribute__((externally_visible, used, section(".thread_create") ))
+#define CMRX_APPLICATION_INSTANCE_ATTRIBUTES __attribute__((used, section(".applications") ))
+#define CMRX_THREAD_AUTOCREATE_ATTRIBUTES __attribute__((used, section(".thread_create") ))
 
 #define CMRX_APPLICATION_INSTANCE_CONSTRUCTOR(application) \
 extern void * __APPL_SYMBOL(application, data_start);\
@@ -28,7 +28,7 @@ CMRX_APPLICATION_INSTANCE_ATTRIBUTES const struct OS_process_definition_t __APPL
         { &__APPL_SYMBOL(application, shared_start), &__APPL_SYMBOL(application, shared_end) }\
     },\
     { &__APPL_SYMBOL(application, vtable_start), &__APPL_SYMBOL(application, vtable_end) }\
-};
+}
 
 #define CMRX_THREAD_AUTOCREATE_CONSTRUCTOR(application, entrypoint, data, priority, core) \
 CMRX_THREAD_AUTOCREATE_ATTRIBUTES const struct OS_thread_create_t __APPL_SYMBOL(application, thread_create_ ## entrypoint) = {\
@@ -37,4 +37,4 @@ CMRX_THREAD_AUTOCREATE_ATTRIBUTES const struct OS_thread_create_t __APPL_SYMBOL(
     data,\
     priority,\
     core\
-};
+}


### PR DESCRIPTION
ARM port emits some warnings which may become errors if -Wall -Werror is chosen in the build. They don't affect the build performance nor functionality but may break build in these strict settings.

Fixed typo in attribute 'sed' -> 'used'
Removed externally_visible from the attribute and removed trailing semicolons from two macro implementations. This allows developers to put semicolon where the macro is used.