### PR TITLE
Fix: Add missing os_core_sleep to enable idling

### DIFF
--- a/src/os/arch/linux/linux.c
+++ b/src/os/arch/linux/linux.c
@@ -557,3 +557,8 @@ struct Syscall_Entry_t * os_syscalls_end(void)
 {
     return &syscalls[syscalls_count];
 }
+
+void os_core_sleep()
+{
+    sleep(1);
+}

--- a/src/os/arch/linux/posix/arch/corelocal.h
+++ b/src/os/arch/linux/posix/arch/corelocal.h
@@ -13,3 +13,5 @@
 #define coreid() 0
 
 #define OS_NUM_CORES	1
+
+void os_core_sleep(void);


### PR DESCRIPTION
Linux port was idling using busy wait which meant it loaded one CPU core to 100%. This fix adds missing function that does internal interruptible sleep when CPU shutdown while idling is activated in CMRX configuration.