### PR TITLE
ci: MemBrowse integration

### DIFF
--- a/.github/membrowse-targets.json
+++ b/.github/membrowse-targets.json
@@ -1,0 +1,38 @@
+[
+  {
+    "target_name": "stm32g4",
+    "source_dir": "stm32g4-cubemx",
+    "build_cmd": "cmake -S _integ/stm32g4-cubemx -B build -DCMRX_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug && (cmake --build build || true) && cmake --build build",
+    "elf": "build/stm32g4-cubemx.elf",
+    "ld": "_integ/stm32g4-cubemx/stm32g491cctx_flash.ld",
+    "map_file": "build/stm32g4-cubemx.map",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "stm32h7",
+    "source_dir": "stm32h7-cubemx",
+    "build_cmd": "cmake -S _integ/stm32h7-cubemx -B build -DCMRX_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug && (cmake --build build || true) && cmake --build build",
+    "elf": "build/tmp-cmrx-integration-build.elf",
+    "ld": "_integ/stm32h7-cubemx/stm32h753vihx_flash.ld",
+    "map_file": "build/tmp-cmrx-integration-build.map",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "rp2040",
+    "source_dir": "rp2040-pico-sdk",
+    "build_cmd": "cmake -S _integ/rp2040-pico-sdk -B build -DCMRX_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DPICO_SDK_PATH=$GITHUB_WORKSPACE/_integ/rp2040-pico-sdk/pico-sdk && (cmake --build build || true) && cmake --build build && printf 'MEMORY {\\n    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 2048K\\n    RAM(rwx) : ORIGIN = 0x20000000, LENGTH = 256k\\n    SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k\\n    SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k\\n}\\n' > build/rp2040_memory.ld",
+    "elf": "build/helloworld.elf",
+    "ld": "build/rp2040_memory.ld",
+    "map_file": "build/helloworld.map",
+    "linker_vars": ""
+  },
+  {
+    "target_name": "linux",
+    "source_dir": "linux-posix",
+    "build_cmd": "cmake -S _integ/linux-posix -B build -DCMRX_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug && cmake --build build",
+    "elf": "build/cmrx-on-linux",
+    "ld": "",
+    "map_file": "build/cmrx-on-linux.map",
+    "linker_vars": ""
+  }
+]

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,30 +1,38 @@
 name: 'Build: Linux'
+
 on:
+  pull_request:
   push:
-    branches: [ master ]
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-project:
     runs-on: ubuntu-latest
     steps:
-     - name: Checkout Test Sources
+     - name: Checkout repository
+       uses: actions/checkout@v4.1.6
+       with:
+         fetch-depth: 0
+
+     - name: Checkout Integration Tests
        uses: actions/checkout@v4.1.6
        with:
          repository: ventZl/cmrx-integration-tests
-         submodules: 'false'
+         path: _integ
 
-     - name: Checkout Latest CMRX Kernel
-       uses: actions/checkout@v4.1.6
-       with:
-         repository: ventZl/cmrx
-         path: linux-posix/cmrx
-         submodules: 'false'
+     - name: Link CMRX source
+       run: rm -rf _integ/linux-posix/cmrx && ln -s $GITHUB_WORKSPACE _integ/linux-posix/cmrx
 
      - name: Configure Integration Test Build
        uses: threeal/cmake-action@main
        with:
         run-build: false
-        source-dir: linux-posix
+        source-dir: _integ/linux-posix
         build-dir: build
         args: -DCMRX_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug
 
@@ -34,3 +42,14 @@ jobs:
 
      - name: Build Integration Test
        run: make -C build
+
+     - name: Run MemBrowse analysis
+       uses: membrowse/membrowse-action@v1
+       with:
+         target_name: linux
+         elf: build/cmrx-on-linux
+         ld: ''
+         map_file: build/cmrx-on-linux.map
+         api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+         api_url: ${{ vars.MEMBROWSE_API_URL }}
+         verbose: INFO

--- a/.github/workflows/membrowse-comment.yml
+++ b/.github/workflows/membrowse-comment.yml
@@ -1,0 +1,30 @@
+name: MemBrowse PR Comment
+
+on:
+  workflow_run:
+    workflows: ['Build: stm32g4', 'Build: stm32h7', 'Build: rp2040', 'Build: Linux']
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.6
+
+      - name: Post combined PR comment
+        if: ${{ env.MEMBROWSE_API_KEY != '' }}
+        uses: membrowse/membrowse-action/comment-action@v1
+        with:
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          commit: ${{ github.event.workflow_run.head_sha }}
+        env:
+          MEMBROWSE_API_KEY: ${{ secrets.MEMBROWSE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/membrowse-onboard.yml
+++ b/.github/workflows/membrowse-onboard.yml
@@ -1,0 +1,73 @@
+name: Onboard to MemBrowse
+
+on:
+  workflow_dispatch:
+    inputs:
+      num_commits:
+        description: 'Number of commits to process'
+        required: true
+        default: '100'
+        type: string
+
+jobs:
+  load-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.6
+
+      - name: Load target matrix
+        id: set-matrix
+        run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
+
+  onboard:
+    needs: load-targets
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare Cross-Toolchain Environment
+        if: matrix.target_name != 'linux'
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        with:
+          release: '12.2.Rel1'
+
+      - name: Checkout Integration Tests
+        uses: actions/checkout@v4.1.6
+        with:
+          repository: ventZl/cmrx-integration-tests
+          path: _integ
+
+      - name: Checkout Raspberry Pi Pico SDK
+        if: matrix.target_name == 'rp2040'
+        uses: actions/checkout@v4.1.6
+        with:
+          repository: raspberrypi/pico-sdk
+          path: _integ/rp2040-pico-sdk/pico-sdk
+
+      - name: Link CMRX source
+        run: rm -rf _integ/${{ matrix.source_dir }}/cmrx && ln -s $GITHUB_WORKSPACE _integ/${{ matrix.source_dir }}/cmrx
+
+      - name: Run MemBrowse Onboard Action
+        uses: membrowse/membrowse-action/onboard-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          num_commits: ${{ github.event.inputs.num_commits }}
+          build_script: ${{ matrix.build_cmd }}
+          elf: ${{ matrix.elf }}
+          ld: ${{ matrix.ld }}
+          map_file: ${{ matrix.map_file }}
+          linker_vars: ${{ matrix.linker_vars }}
+          binary_search: 'true'
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}

--- a/.github/workflows/rp2040-build.yml
+++ b/.github/workflows/rp2040-build.yml
@@ -1,7 +1,14 @@
 name: 'Build: rp2040'
+
 on:
+  pull_request:
   push:
-    branches: [ master ]
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-project:
@@ -11,33 +18,34 @@ jobs:
        uses: carlosperate/arm-none-eabi-gcc-action@v1
        with:
          release: '12.2.Rel1'
-     - name: Checkout Test Sources
+
+     - name: Checkout repository
+       uses: actions/checkout@v4.1.6
+       with:
+         fetch-depth: 0
+
+     - name: Checkout Integration Tests
        uses: actions/checkout@v4.1.6
        with:
          repository: ventZl/cmrx-integration-tests
-         submodules: 'false'
+         path: _integ
 
-     - name: Checkout Latest CMRX Kernel
-       uses: actions/checkout@v4.1.6
-       with:
-         repository: ventZl/cmrx
-         path: rp2040-pico-sdk/cmrx
-         submodules: 'false'
-
-     - name: Checkout Latest Raspberry Pi Pico SDK
+     - name: Checkout Raspberry Pi Pico SDK
        uses: actions/checkout@v4.1.6
        with:
          repository: raspberrypi/pico-sdk
-         path: rp2040-pico-sdk/pico-sdk
-         submodules: 'false'
+         path: _integ/rp2040-pico-sdk/pico-sdk
+
+     - name: Link CMRX source
+       run: rm -rf _integ/rp2040-pico-sdk/cmrx && ln -s $GITHUB_WORKSPACE _integ/rp2040-pico-sdk/cmrx
 
      - name: Configure Integration Test Build
        uses: threeal/cmake-action@main
        with:
         run-build: false
-        source-dir: rp2040-pico-sdk
+        source-dir: _integ/rp2040-pico-sdk
         build-dir: build
-        args: -DCMRX_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DPICO_SDK_PATH=${{github.workspace}}/rp2040-pico-sdk/pico-sdk
+        args: -DCMRX_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug -DPICO_SDK_PATH=${{github.workspace}}/_integ/rp2040-pico-sdk/pico-sdk
 
      - name: Pre-build Integration Test
        run: make -C build
@@ -45,3 +53,18 @@ jobs:
 
      - name: Build Integration Test
        run: make -C build
+
+     - name: Generate RP2040 memory regions
+       run: |
+         printf 'MEMORY {\n    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 2048K\n    RAM(rwx) : ORIGIN = 0x20000000, LENGTH = 256k\n    SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k\n    SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k\n}\n' > build/rp2040_memory.ld
+
+     - name: Run MemBrowse analysis
+       uses: membrowse/membrowse-action@v1
+       with:
+         target_name: rp2040
+         elf: build/helloworld.elf
+         ld: build/rp2040_memory.ld
+         map_file: build/helloworld.map
+         api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+         api_url: ${{ vars.MEMBROWSE_API_URL }}
+         verbose: INFO

--- a/.github/workflows/stm32g4-build.yml
+++ b/.github/workflows/stm32g4-build.yml
@@ -1,7 +1,14 @@
 name: 'Build: stm32g4'
+
 on:
+  pull_request:
   push:
-    branches: [ master ]
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-project:
@@ -11,24 +18,26 @@ jobs:
        uses: carlosperate/arm-none-eabi-gcc-action@v1
        with:
          release: '12.2.Rel1'
-     - name: Checkout Test Sources
+
+     - name: Checkout repository
+       uses: actions/checkout@v4.1.6
+       with:
+         fetch-depth: 0
+
+     - name: Checkout Integration Tests
        uses: actions/checkout@v4.1.6
        with:
          repository: ventZl/cmrx-integration-tests
-         submodules: 'false'
+         path: _integ
 
-     - name: Checkout Latest CMRX Kernel
-       uses: actions/checkout@v4.1.6
-       with:
-         repository: ventZl/cmrx
-         path: stm32g4-cubemx/cmrx
-         submodules: 'false'
+     - name: Link CMRX source
+       run: rm -rf _integ/stm32g4-cubemx/cmrx && ln -s $GITHUB_WORKSPACE _integ/stm32g4-cubemx/cmrx
 
      - name: Configure Integration Test Build
        uses: threeal/cmake-action@main
        with:
         run-build: false
-        source-dir: stm32g4-cubemx
+        source-dir: _integ/stm32g4-cubemx
         build-dir: build
         args: -DCMRX_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug
 
@@ -38,3 +47,14 @@ jobs:
 
      - name: Build Integration Test
        run: make -C build
+
+     - name: Run MemBrowse analysis
+       uses: membrowse/membrowse-action@v1
+       with:
+         target_name: stm32g4
+         elf: build/stm32g4-cubemx.elf
+         ld: _integ/stm32g4-cubemx/stm32g491cctx_flash.ld
+         map_file: build/stm32g4-cubemx.map
+         api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+         api_url: ${{ vars.MEMBROWSE_API_URL }}
+         verbose: INFO

--- a/.github/workflows/stm32h7-build.yml
+++ b/.github/workflows/stm32h7-build.yml
@@ -1,7 +1,14 @@
 name: 'Build: stm32h7'
+
 on:
+  pull_request:
   push:
-    branches: [ master ]
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-project:
@@ -11,24 +18,26 @@ jobs:
        uses: carlosperate/arm-none-eabi-gcc-action@v1
        with:
          release: '12.2.Rel1'
-     - name: Checkout Test Sources
+
+     - name: Checkout repository
+       uses: actions/checkout@v4.1.6
+       with:
+         fetch-depth: 0
+
+     - name: Checkout Integration Tests
        uses: actions/checkout@v4.1.6
        with:
          repository: ventZl/cmrx-integration-tests
-         submodules: 'false'
+         path: _integ
 
-     - name: Checkout Latest CMRX Kernel
-       uses: actions/checkout@v4.1.6
-       with:
-         repository: ventZl/cmrx
-         path: stm32h7-cubemx/cmrx
-         submodules: 'false'
+     - name: Link CMRX source
+       run: rm -rf _integ/stm32h7-cubemx/cmrx && ln -s $GITHUB_WORKSPACE _integ/stm32h7-cubemx/cmrx
 
      - name: Configure Integration Test Build
        uses: threeal/cmake-action@main
        with:
         run-build: false
-        source-dir: stm32h7-cubemx
+        source-dir: _integ/stm32h7-cubemx
         build-dir: build
         args: -DCMRX_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug
 
@@ -38,3 +47,14 @@ jobs:
 
      - name: Build Integration Test
        run: make -C build
+
+     - name: Run MemBrowse analysis
+       uses: membrowse/membrowse-action@v1
+       with:
+         target_name: stm32h7
+         elf: build/tmp-cmrx-integration-build.elf
+         ld: _integ/stm32h7-cubemx/stm32h753vihx_flash.ld
+         map_file: build/tmp-cmrx-integration-build.map
+         api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+         api_url: ${{ vars.MEMBROWSE_API_URL }}
+         verbose: INFO

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 CMRX - Microkernel RTOS for microcontrollers
 ============================================
 
-![unit tests](https://github.com/ventZl/cmrx/actions/workflows/unit_tests.yml/badge.svg) [![Clang-Tidy](https://github.com/ventZl/cmrx/actions/workflows/clang_tidy.yml/badge.svg?branch=master)](https://github.com/ventZl/cmrx/actions/workflows/clang_tidy.yml) ![stm32h7 build](https://github.com/ventZl/cmrx/actions/workflows/stm32h7-build.yml/badge.svg) ![stm32g4 build](https://github.com/ventZl/cmrx/actions/workflows/stm32g4-build.yml/badge.svg) ![rp2040 build](https://github.com/ventZl/cmrx/actions/workflows/rp2040-build.yml/badge.svg) [![Linux build](https://github.com/ventZl/cmrx/actions/workflows/linux-build.yml/badge.svg)](https://github.com/ventZl/cmrx/actions/workflows/linux-build.yml)
+![unit tests](https://github.com/ventZl/cmrx/actions/workflows/unit_tests.yml/badge.svg) [![Clang-Tidy](https://github.com/ventZl/cmrx/actions/workflows/clang_tidy.yml/badge.svg?branch=master)](https://github.com/ventZl/cmrx/actions/workflows/clang_tidy.yml) ![stm32h7 build](https://github.com/ventZl/cmrx/actions/workflows/stm32h7-build.yml/badge.svg) ![stm32g4 build](https://github.com/ventZl/cmrx/actions/workflows/stm32g4-build.yml/badge.svg) ![rp2040 build](https://github.com/ventZl/cmrx/actions/workflows/rp2040-build.yml/badge.svg) [![Linux build](https://github.com/ventZl/cmrx/actions/workflows/linux-build.yml/badge.svg)](https://github.com/ventZl/cmrx/actions/workflows/linux-build.yml) [![MemBrowse](https://membrowse.com/badge.svg)](https://membrowse.com/public/ventZl/cmrx)
 
 **Table of Contents**
 - [About](#about)


### PR DESCRIPTION
Summary

  CMRX has build workflows for its integration test targets but no automated way to track how PRs affect memory footprint over time.

  This PR adds MemBrowse CI integration for automated memory footprint analysis on pull requests.

  Here is an example of the dashboard: https://membrowse.com/public/michael-membrowse/cmrx

  This includes:

  - membrowse-targets.json - configuration of the targets to be analyzed
  - Existing build workflows (stm32g4, stm32h7, rp2040, linux) - extended with pull_request trigger, concurrency settings, and a MemBrowse analysis step at the end of each build
  - membrowse-onboard.yml - one-off workflow for building the last N commits to populate historical data on day one
  - README badge linking to the MemBrowse dashboard

  Currently the integration covers 4 targets: stm32g4, stm32h7, rp2040, and linux.

  Setup

  1. Create account at https://membrowse.com
  2. Create a project and link it to this repo
  3. Set the project as publicly available
  4. Add MEMBROWSE_API_KEY as a GitHub Actions secret
  5. Run the onboard workflow to populate the dashboard with historical data