### PR TITLE
ARM: Support for secure mode execution

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -13,6 +13,7 @@ option(CMRX_INTEGRATION_TESTS "Enable build of integration tests. Implies CMRX_H
 option(CMRX_HIL_TESTING_SKIP_OPENOCD "Skip OpenOCD initialization during integration tests." OFF)
 option(CMRX_USE_FAST_HASH "Use fast hashing function at expense of hash quality" OFF)
 option(CMRX_VERBOSE_API_NAMES "Prefix all CMRX standard library function names with `cmrx_` to avoid conflicts" OFF)
+option(CMRX_ARCH_ARMV8M_SECURE_MODE "Run in secure mode on ARMv8M CPUs" OFF)
 set(OS_STACK_SIZE 1024 CACHE STRING "Stack allocated per thread in bytes")
 set(OS_THREADS 8 CACHE STRING "Amount of entries in the thread table")
 set(OS_PROCESSES 8 CACHE STRING "Amount of entries in the process table")

--- a/conf/kernel.h
+++ b/conf/kernel.h
@@ -89,4 +89,12 @@
  * There is no functional change.
  */
 #cmakedefine CMRX_VERBOSE_API_NAMES
+
+/** Select secure/non-secure execution mode on ARMv8M.
+ * If enabled, CMRX will execute in secure mode both CMRX kernel and all threads.
+ * As of now, CMRX can't mix secure + non-secure execution and user has to select
+ * mode depending on presence / absence of secure firmware that switches CPU into
+ * non-secure mode.
+ */
+#cmakedefine CMRX_ARCH_ARMV8M_SECURE_MODE
 /** @} */

--- a/src/os/arch/arm/sched.c
+++ b/src/os/arch/arm/sched.c
@@ -44,8 +44,12 @@ void os_thread_initialize_arch(struct OS_thread_t * thread, unsigned stack_size,
 	// without FPU
 #	if defined(__ARM_ARCH_8M_BASE__) || defined(__ARM_ARCH_8M_MAIN__)
 #	define EXC_RETURN_RES1 0xFFFF80UL
+#		if defined(CMRX_ARCH_ARMV8M_SECURE_MODE)
+	thread->arch.exc_return = EXC_RETURN_PREFIX | EXC_RETURN_RES1 | EXC_RETURN_S | EXC_RETURN_DCRS | EXC_RETURN_FTYPE | EXC_RETURN_MODE | EXC_RETURN_SPSEL | EXC_RETURN_ES;
+#		else
 	thread->arch.exc_return = EXC_RETURN_PREFIX | EXC_RETURN_RES1 | EXC_RETURN_DCRS | EXC_RETURN_FTYPE | EXC_RETURN_MODE | EXC_RETURN_SPSEL;
-#	else
+#		endif
+	#	else
 	thread->arch.exc_return = EXC_RETURN_THREAD_PSP;
 #	endif
 #endif


### PR DESCRIPTION
Add support for running in ARMv8M secure mode. This happens if CMRX is loaded without secure firmware which will switch CPU into non-secure execution mode.

For now the only difference is that correct flags are set in EXC_RETURN so stacks configured in secure mode are used rather than non-secure stacks used when CMRX is running in non-secure mode and/or on Cortex-M33 machine which does not support security extensions.