### PR TITLE
Add support for platform automation

### DIFF
--- a/.github/workflows/rp2040-build.yml
+++ b/.github/workflows/rp2040-build.yml
@@ -34,6 +34,7 @@ jobs:
        uses: actions/checkout@v4.1.6
        with:
          repository: raspberrypi/pico-sdk
+         ref: 2.2.0
          path: _integ/rp2040-pico-sdk/pico-sdk
 
      - name: Link CMRX source

--- a/cmake/CMRX.cmake
+++ b/cmake/CMRX.cmake
@@ -1,13 +1,36 @@
 cmake_minimum_required(VERSION 3.18)
 
+
 find_program(PYTHON_EXE NAMES python3 python REQUIRED DOC "Python 3 executable")
 
+if (DEFINED CMRX_DEVICE)
+    set(DEVICE "${CMRX_DEVICE}")
+    string(LENGTH "${CMRX_DEVICE}" _DEV_LEN)
+    set(_DEV_PREFIX_LEN 2)
+    while(_DEV_PREFIX_LEN LESS _DEV_LEN)
+        string(SUBSTRING "${CMRX_DEVICE}" 0 ${_DEV_PREFIX_LEN} _DEV_PREFIX)
+        string(TOLOWER "${_DEV_PREFIX}" _DEV_PREFIX)
+        set(PLATFORM_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/platform/${_DEV_PREFIX}.cmake")
+        if (EXISTS ${PLATFORM_SCRIPT})
+            include(${PLATFORM_SCRIPT})
+            break()
+        endif()
+        math(EXPR _DEV_PREFIX_LEN "${_DEV_PREFIX_LEN} + 1")
+    endwhile()
+endif()
+
 if ("${CMRX_ARCH}" STREQUAL "")
-    message(FATAL_ERROR "CMRX_ARCH not defined! Please define target architecture to be used!")
+    get_property(CMRX_ARCH GLOBAL PROPERTY CMRX_ARCH)
+    if (NOT DEFINED CMRX_ARCH)
+        message(FATAL_ERROR "CMRX_ARCH not defined! Please define target architecture to be used!")
+    endif()
 endif()
 
 if ("${CMRX_HAL}" STREQUAL "")
-    message(FATAL_ERROR "CMRX_HAL not defined! Please define target HAL to be used!")
+    get_property(CMRX_HAL GLOBAL PROPERTY CMRX_HAL)
+    if (NOT DEFINED CMRX_HAL)
+        message(FATAL_ERROR "CMRX_HAL not defined! Please define target HAL to be used!")
+    endif()
 endif()
 
 option(SW_TESTING_BUILD "Enabled hosted build. This can be used to build hosted unit tests." FALSE)

--- a/cmake/platform/rp2.cmake
+++ b/cmake/platform/rp2.cmake
@@ -1,0 +1,31 @@
+# Module automating support for PicoSDK-based projects for RP2xxx family of microcontrollers
+string(TOLOWER "${CMRX_DEVICE}" PICO_DEVICE)
+string(TOUPPER "${CMRX_DEVICE}" DEVICE)
+
+if (NOT DEFINED PICO_SDK_PATH)
+    message(FATAL_ERROR "Pico SDK path not defined! Set variable `PICO_SDK_PATH` to point to Pico SDK location.")
+endif()
+
+if (DEFINED CMRX_LINKER_FILE)
+    if (NOT EXISTS "${CMRX_LINKER_FILE}")
+        message(FATAL_ERROR "Specified linker file doesn't exist: ${CMRX_LINKER_FILE}")
+    endif()
+else()
+    set(CMSIS_LINKER_FILE "${CMRX_LINKER_FILE}")
+    set(CMSIS_LINKER_FILE ${PICO_SDK_PATH}/rp2_common/pico_crt0/${PICO_DEVICE}/memmap_default.ld)
+    if (NOT EXISTS "{CMSIS_LINKER_FILE}")
+        # In the past, PicoSDK changed the location of linker files at least once
+        message(FATAL_ERROR "Unable to find Pico SDK linker file for ${DEVICE}! Check Pico SDK installation and compatibility!")
+    endif()
+endif()
+
+set(CMSIS_ROOT ${PICO_SDK_PATH}/src/rp2_common/cmsis/stub/CMSIS)
+if (NOT EXISTS "${CMSIS_ROOT}")
+    message(FATAL_ERROR "Unable to find Pico SDK CMSIS headers! Check Pico SDK installation and compatibility!")
+endif()
+
+include(../FindCMSIS.cmake)
+
+set_property(GLOBAL PROPERTY CMRX_ARCH arm)
+set_property(GLOBAL PROPERTY CMRX_HAL cmsis)
+

--- a/cmake/platform/stm32.cmake
+++ b/cmake/platform/stm32.cmake
@@ -1,0 +1,45 @@
+# Module automating support for CubeMX-based projects for STM32 family of microcontrollers
+
+set_property(GLOBAL PROPERTY CMRX_ARCH arm)
+set_property(GLOBAL PROPERTY CMRX_HAL cmsis)
+set(DEVICE ${CMRX_DEVICE})
+string(TOUPPER "${CMRX_DEVICE}" _CMRX_DEVICE_UPCASE)
+add_definitions(-D${_CMRX_DEVICE_UPCASE})
+string(SUBSTRING "${CMRX_DEVICE}" 0 7 _STM_FAMILY)
+string(TOLOWER "${_STM_FAMILY}" _STM_FAMILY)
+
+set(SYSTEM_INCLUDE_FILENAME system_${_STM_FAMILY}xx.h)
+
+# Assume default CubeMX CMake project layout
+if (NOT EXISTS ${CMAKE_SOURCE_DIR}/Drivers/CMSIS)
+    message(FATAL_ERROR "CubeMX CMSIS package not found! STM32 platform support assumes default CubeMX project layout. Reorganize project or use manual HAL integration")
+endif()
+
+set(CMSIS_ROOT ${CMAKE_SOURCE_DIR}/Drivers/CMSIS)
+
+if (DEFINED CMRX_LINKER_FILE)
+    if (NOT EXISTS "${CMRX_LINKER_FILE}")
+        message(FATAL_ERROR "Specified linker file doesn't exist: ${CMRX_LINKER_FILE}")
+    endif()
+    set(CMSIS_LINKER_FILE "${CMRX_LINKER_FILE}")
+else()
+    file(GLOB CMSIS_LINKER_FILE LIST_DIRECTORIES false "${CMAKE_SOURCE_DIR}/${_STM_FAMILY}*.ld")
+    list(LENGTH CMSIS_LINKER_FILE _LINKER_FILES_FOUND)
+    if (NOT "${_LINKER_FILES_FOUND}" STREQUAL 1)
+        message(FATAL_ERROR "Unable to identify project linker file automatically! Either set variable `CMRX_LINKER_FILE` to contain path to linker file used or place exactly one linker file having pattern ${_STM_FAMILY}*.ld into ${CMAKE_SOURCE_DIR}")
+    endif()
+endif()
+
+include(${CMAKE_CURRENT_LIST_DIR}/../FindCMSIS.cmake)
+
+if (NOT TARGET stm32cubemx)
+    message(FATAL_ERROR "Target stm32cubemx not defined! Please, add directory cmake/stm32cubemx before including CMRX CMake module so CubeMX can be detected properly.")
+endif()
+
+get_target_property(CUBEMX_INCLUDE_DIRECTORIES stm32cubemx INTERFACE_INCLUDE_DIRECTORIES)
+get_target_property(CUBEMX_COMPILE_DEFINITIONS stm32cubemx INTERFACE_COMPILE_DEFINITIONS)
+
+add_library(stm32cubemx_headers INTERFACE)
+target_include_directories(stm32cubemx_headers INTERFACE ${CUBEMX_INCLUDE_DIRECTORIES})
+target_compile_definitions(stm32cubemx_headers INTERFACE ${CUBEMX_COMPILE_DEFINITIONS})
+


### PR DESCRIPTION
Add support for platform-specific automations and specifics. This mechanism is optional and can be used to integrate certain supported HALs with less effort than if FindCMSIS is configured manually.

If platform support is to be used, following changes have to be made to top-level CMakeLists.txt:

Pass full chip part name as recognized by your HAL in `CMRX_DEVICE` variable instead of `DEVICE` variable. E.g.:

set(CMRX_DEVICE stm32h753xx)

Optionally, pass linker script path in `CMRX_LINKER_FILE` variable. If this is not specified, platform support will try to find linker file automatically if any rules for where it is located are established in HAL being used.

Do not include FindCMSIS manually. Remove its inclusion. Remove setting of DEVICE, CMSIS_ROOT, CMSIS_LINKER_FILE and any other FindCMSIS configuration variables, these will be configured automatically.

Include CMRX.cmake

If CMRX_DEVICE variable is defined, then CMRX CMake module will try to find platform support module for this device. This module is stored in directory cmake/platform and shortest lowercase prefix of path name long at least two characters is chosen as platform. So for STM32H753xx, the platform file will be cmake/platform/stm32.cmake as no shorter prefix of part name exists in cmake/platform directory.

Platform support script must set all necessary variables and properties so CMRX kernel is able to configure itself, build and link.