### PR TITLE
docs: fix stale file references in pico-sdk-riscv quirk README

### DIFF
--- a/quirks/pico-sdk-riscv/README.md
+++ b/quirks/pico-sdk-riscv/README.md
@@ -9,28 +9,45 @@ are checked and executed at defined boundaries (typically trap/IRQ exit). The po
 RISC-V code provides the safe-point function but does not hook it into any specific
 trap entry/exit mechanism.
 
-On Pico SDK for RISC-V, the external IRQ handler (`isr_riscv_machine_external_irq`) is
-declared weak in `crt0_riscv.S`, allowing it to be overridden.
+Pico SDK's `crt0_riscv.S` and `exception_table_riscv.S` declare the machine timer ISR
+(`isr_riscv_machine_timer`) and the machine exception handler (`isr_riscv_machine_exception`)
+as weak, allowing them to be overridden.
 
 ## Solution
 
-This quirk provides a replacement `isr_riscv_machine_external_irq` that:
+This quirk provides full-`ExceptionFrame`-aware replacements for both weak handlers, plus
+the ecall handler CMRX needs on top of them:
 
-1. Performs the same IRQ dispatch as the original Pico SDK handler
-2. Calls `os_riscv_context_switch_safe_point()` after all IRQs are dispatched
-3. Restores context and returns via `mret`
+1. `isr_riscv_machine_timer` saves the complete `ExceptionFrame`, calls
+   `cmrx_machine_timer_handler()` (the application-provided timing provider hook), then calls
+   `os_riscv_context_switch_safe_point()` before restoring context and returning via `mret`.
+2. `isr_riscv_machine_exception` saves the complete `ExceptionFrame`, dispatches to the
+   individual exception handler for the trap cause (passing it the `ExceptionFrame` pointer),
+   then also calls `os_riscv_context_switch_safe_point()` before restoring context and
+   returning via `mret`.
+3. `cmrx_ecall_handler.c` provides the `ecall` (syscall) exception handler invoked by (2):
+   it advances `mepc` past the `ecall` instruction, dispatches the CMRX syscall, and writes
+   the return value into the frame's `a0`.
 
-The safe-point call happens at a well-defined boundary where:
-- All IRQs have been serviced
+In both (1) and (2), the safe-point call happens at a well-defined boundary where:
+- The interrupt/exception has been fully serviced
 - IRQs are globally disabled (`mstatus.MIE` = 0)
-- Caller-saved registers are saved on the stack
+- The complete register state is saved on the stack (`ExceptionFrame`)
 
 ## Files
 
-- `crt0_riscv_cmrx.S` - Replacement external IRQ handler with safe-point hook
-- `CMakeLists.txt` - Build integration (activated when `PICO_PLATFORM=rp2350-riscv`)
+- `cmrx_timer_isr.c` - Machine timer ISR override with full `ExceptionFrame` save/restore.
+- `cmrx_exception_dispatcher.c` - Machine exception handler override with full `ExceptionFrame`
+  save/restore and exception table dispatch.
+- `cmrx_ecall_handler.c` - `ecall` (syscall) exception handler for CMRX syscalls, invoked by
+  the exception dispatcher above.
+- `CMakeLists.txt` - Build integration.
 
 ## Usage
 
-This quirk is automatically enabled when building CMRX for Pico SDK RISC-V. Ensure the
-quirks subdirectory is included after the main CMRX target is defined.
+This quirk activates only when `PICO_PLATFORM` is set to `rp2350-riscv`; its `CMakeLists.txt`
+returns immediately otherwise, so it is safe to always include it in a project even if that
+project might also target other platforms. When active, it appends its sources to the `os`
+target, adds CMRX's own `include/` directory as a private include path, and links
+`pico_base_headers` and `hardware_regs`. Ensure the quirk's subdirectory is added after the
+main CMRX target is defined, so it can attach its sources to `os`.


### PR DESCRIPTION
   ## Summary                                                                                                                                                                           
                                                                                                                                                                                        
   Fix stale documentation in `quirks/pico-sdk-riscv/README.md` to accurately describe the actual integration code in this directory.                                                   
                                                                                                                                                                                        
   ## Problem                                                                                                                                                                           

   The quirk README describes a `crt0_riscv_cmrx.S` file and an `isr_riscv_machine_external_irq` override that do not exist in this directory. This mismatch between documentation and  
 reality creates confusion for anyone trying to understand or maintain this code. The actual files (`cmrx_timer_isr.c`, `cmrx_exception_dispatcher.c`, `cmrx_ecall_handler.c`) and      
 their purposes went undocumented.            

   ## Changes                                 

   - **Files section**: replaced nonexistent filenames with the actual files present in the directory, with descriptions of what each does:                                             
     - `cmrx_timer_isr.c` — machine timer ISR with full exception frame save/restore        
     - `cmrx_exception_dispatcher.c` — machine exception handler with exception table dispatch                                                                                          
     - `cmrx_ecall_handler.c` — `ecall` (syscall) exception handler for CMRX syscalls       

   - **Solution section**: expanded to describe the actual behavior:                        
     - Both the timer ISR and exception handler save the full `ExceptionFrame` before calling the safe-point                                                                            
     - The exception handler dispatches to individual handlers based on trap cause          
     - The ecall handler advances `mepc` and writes return values into the frame            

   - **Problem section**: corrected which weak handlers are overridden (machine timer and machine exception, not just external IRQ)                                                     

   - **Usage section**: clarified that the quirk activates only when `PICO_PLATFORM=rp2350-riscv` and documents the CMake integration (appends to `os` target, links `hardware_regs`    
 and `pico_base_headers`)