### PR TITLE
cmake: detect RP2350 RISC-V core in rp2 platform automation

### DIFF
--- a/cmake/platform/rp2.cmake
+++ b/cmake/platform/rp2.cmake
@@ -1,4 +1,15 @@
 # Module automating support for PicoSDK-based projects for RP2xxx family of microcontrollers
+
+# RP2350 RISC-V (Hazard3) core: bypass the CMSIS/ARM detection below entirely. PICO_PLATFORM
+# is the signal the pico-sdk-riscv quirk itself already keys on, and is guaranteed to be set
+# well before this file is ever reached (Pico SDK reads it during pico_sdk_import, which runs
+# before include(CMRX)).
+if (PICO_PLATFORM STREQUAL "rp2350-riscv")
+    set_property(GLOBAL PROPERTY CMRX_ARCH riscv)
+    set_property(GLOBAL PROPERTY CMRX_HAL hal)
+    return()
+endif()
+
 string(TOLOWER "${CMRX_DEVICE}" PICO_DEVICE)
 string(TOUPPER "${CMRX_DEVICE}" DEVICE)
 


### PR DESCRIPTION
   ## Summary                                                                                                                                                                           
                                                                                                                                                                                        
   Fix the rp2 platform automation to correctly detect and configure RP2350 RISC-V builds instead of silently forcing ARM/CMSIS for all RP2xxx devices.                                 
                                                                                                                                                                                        
   ## Problem                                                                                                                                                                           
                                                                                                                                                                                        
   The `cmake/platform/rp2.cmake` module is the platform-automation convenience path for RP2xxx devices. Currently it unconditionally sets `CMRX_ARCH arm` / `CMRX_HAL cmsis` and       
 includes `FindCMSIS` for every device matching the `rp2` prefix, including RP2350 RISC-V. A project using `CMRX_DEVICE=rp2350` with `PICO_PLATFORM=rp2350-riscv` would be silently     
 misconfigured for the wrong architecture instead of receiving a clear error.                                                                                                           
                                                                                                                                                                                        
   (Note: the documented path and the unmerged integration-test reference project both bypass this automation and set `CMRX_ARCH`/`CMRX_HAL` directly, so no real build is currently    
 broken. This fixes the convenience path for anyone who does use it.)                                                                                                                   
                                                                                                                                                                                        
   ## Changes                                                                                                                                                                           
                                                                                                                                                                                        
   - Add an early detection branch keying on `PICO_PLATFORM STREQUAL "rp2350-riscv"`, which sets the correct `CMRX_ARCH riscv` / `CMRX_HAL hal` and returns immediately, before any     
 ARM/CMSIS logic runs.                                                                                                                                                                  
   - The ARM path below the branch is unchanged; the RP2040 and other ARM RP2xxx variants continue to work exactly as before.                                                           
                                                                                                                                                                                        
   ## Testing                                                                                                                                                                           
                                                                                                                                                                                        
   Verified with a dry cmake configure:                                                                                                                                                 
   - `CMRX_DEVICE=rp2350`, `PICO_PLATFORM=rp2350-riscv` (no `PICO_SDK_PATH` set) → correctly resolves to `CMRX_ARCH=riscv` / `CMRX_HAL=hal`, skips `PICO_SDK_PATH` check, loads the     
 RISC-V HAL module.                                                                                                                                                                     
   - `CMRX_DEVICE=rp2040` (no `PICO_PLATFORM`) → reaches the same `PICO_SDK_PATH` check and linker-file logic as before, no regression.